### PR TITLE
Run git diff against entire repo instead of subdir

### DIFF
--- a/.github/workflows/quick-validation.yml
+++ b/.github/workflows/quick-validation.yml
@@ -54,4 +54,4 @@ jobs:
       - name: go mod vendor
         run: |
           go mod vendor
-          git diff --exit-code vendor/
+          git diff --exit-code


### PR DESCRIPTION
This allows this check to work for projects with and without prexisting vendored dependencies subdirectory.