### PR TITLE
Add gogeninstall input for Makefile jobs

### DIFF
--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -7,6 +7,10 @@
 
 on:
   workflow_call:
+    inputs:
+      gogeninstall:
+        required: false
+        type: boolean
 
 jobs:
   lint_code_with_makefile:
@@ -63,12 +67,24 @@ jobs:
       - name: Print go version
         run: go version
 
-      - name: Check out code into the Go module directory
+      - name: Check out code into the Go module directory (single commit)
+        if: ${{ inputs.gogeninstall == 'false' }}
         uses: actions/checkout@v3.0.2
+
+      - name: Check out code into the Go module directory (full history)
+        if: ${{ inputs.gogeninstall }}
+        uses: actions/checkout@v3.0.2
+        with:
+          # Needed in order to retrieve tags for use with go generate
+          fetch-depth: 0
 
       # bsdmainutils provides "column" which is used by the Makefile
       - name: Install Ubuntu packages
         run: apt-get update && apt-get install -y --no-install-recommends make gcc bsdmainutils
+
+      - name: Install go generate dependencies (if requested)
+        if: ${{ inputs.gogeninstall }}
+        run: make gogeninstall
 
       - name: Build using project Makefile
         run: make all


### PR DESCRIPTION
Setup optional gogeninstall input and use its presence to control whether the `make gogeninstall` command is executed.

If gogeninstall input is set retrieve full history so that all git tags are available for use by go generate tooling, otherwise fallback to default of only retrieving the current commit.