### PR TITLE
Modify Dockerfile linting to lint ALL Dockerfiles

### DIFF
--- a/.github/workflows/lint-project-files.yml
+++ b/.github/workflows/lint-project-files.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.0.2
 
-      - name: Run hadolint against project canary Dockerfile (if present)
-        if: hashFiles('dependabot/docker/go/Dockerfile') != ''
+      - name: Run hadolint against any Dockerfiles
+        if: hashFiles('Dockerfile') != ''
         run: |
           hadolint --version
-          hadolint dependabot/docker/go/Dockerfile
+          find  . -name "Dockerfile" -print -exec hadolint {} \;


### PR DESCRIPTION
Generalize linting step so that all Dockerfiles are linted instead of just one fixed path.