### PR TITLE
Fix syntax used to match any Dockerfile in repo

### DIFF
--- a/.github/workflows/lint-project-files.yml
+++ b/.github/workflows/lint-project-files.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v3.0.2
 
       - name: Run hadolint against any Dockerfiles
-        if: hashFiles('Dockerfile') != ''
+        if: hashFiles('**/Dockerfile') != ''
         run: |
           hadolint --version
           find  . -name "Dockerfile" -print -exec hadolint {} \;


### PR DESCRIPTION
The previous syntax matched only a potential Dockerfile in the root of the project repo.