### PR TITLE
Emit govulncheck version

### DIFF
--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -76,4 +76,5 @@ jobs:
 
       - name: Analyze source code
         run: |
+          echo "govulncheck version $(go version -m $(which govulncheck) | awk '$1 == "mod" { print $3 }')"
           govulncheck -json ./...


### PR DESCRIPTION
Use `go version -m BINARY` for now until govulncheck officially supports a version flag.

fixes GH-18