### PR TITLE
Mark go get job as optional

### DIFF
--- a/.github/workflows/quick-validation.yml
+++ b/.github/workflows/quick-validation.yml
@@ -59,6 +59,9 @@ jobs:
   go_get_update_changes:
     name: Look for available minor or patch releases
     runs-on: ubuntu-latest
+
+    # Mark just this one job as failed, not the whole workflow.
+    continue-on-error: true
     timeout-minutes: 10
     container:
       image: ghcr.io/atc0005/go-ci:go-ci-lint-only


### PR DESCRIPTION
Enable `continue-on-error` setting to allow setting just the job as failed, not the entire workflow.

refs GH-23
refs https://michaelheap.com/testing-experimental-versions-github-actions/