### PR TITLE
Refactor quick-validation workflow file

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -1,0 +1,37 @@
+# Copyright 2022 Adam Chalkley
+#
+# https://github.com/atc0005/shared-project-resources
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+on:
+  workflow_call:
+
+jobs:
+  dependency_updates:
+    name: Look for available minor or patch releases
+    runs-on: ubuntu-latest
+
+    # Mark just this one job as failed, not the whole workflow.
+    continue-on-error: true
+    timeout-minutes: 10
+    container:
+      image: ghcr.io/atc0005/go-ci:go-ci-lint-only
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3.3.0
+
+      # Provided for contrast. Will likely remove this one at some point.
+      - name: go list
+        run: |
+          go list -mod=mod -u -f '{{if .Update}}{{.Path}}: {{.Version}} -> {{.Update.Version}} ({{.Update.Time}}){{end}}' -m all
+          # go list -mod=mod -u -m all
+          # go list -mod=mod -u -json -m all
+
+      - name: go get
+        run: |
+          go get -u ./...
+          go mod tidy
+          git diff --exit-code go.???

--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -1,0 +1,42 @@
+# Copyright 2022 Adam Chalkley
+#
+# https://github.com/atc0005/shared-project-resources
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+on:
+  workflow_call:
+
+jobs:
+  go_mod_changes:
+    name: Look for missing go.mod changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: ghcr.io/atc0005/go-ci:go-ci-lint-only
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3.3.0
+
+      - name: go mod tidy
+        run: |
+          go mod tidy -v
+          git diff --exit-code go.mod
+
+  go_mod_vendor:
+    name: Look for missing vendored dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: ghcr.io/atc0005/go-ci:go-ci-lint-only
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3.3.0
+
+      - name: go mod vendor
+        run: |
+          go mod vendor
+          git diff --exit-code

--- a/.github/workflows/quick-validation.yml
+++ b/.github/workflows/quick-validation.yml
@@ -35,55 +35,10 @@ jobs:
       - name: Run all tests
         run: go test -mod=vendor -v ./...
 
-  go_mod_changes:
-    name: Look for uncommitted Go module changes
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    container:
-      image: ghcr.io/atc0005/go-ci:go-ci-lint-only
+  go_mod_validation:
+    name: Go Module Validation
+    uses: atc0005/shared-project-resources/.github/workflows/go-mod-validation.yml@master
 
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3.3.0
-
-      - name: go mod tidy
-        run: |
-          go mod tidy
-          git diff --exit-code go.mod
-
-      - name: go mod vendor
-        run: |
-          go mod vendor
-          git diff --exit-code
-
-  go_get_update_changes:
-    name: Look for available minor or patch releases
-    runs-on: ubuntu-latest
-
-    # Mark just this one job as failed, not the whole workflow.
-    continue-on-error: true
-    timeout-minutes: 10
-    container:
-      image: ghcr.io/atc0005/go-ci:go-ci-lint-only
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3.3.0
-
-      # Provided for contrast. Will likely remove this one at some point.
-      - name: go list
-        run: |
-          go list -mod=mod -u -f '{{if .Update}}{{.Path}}: {{.Version}} -> {{.Update.Version}} ({{.Update.Time}}){{end}}' -m all
-          # go list -mod=mod -u -m all
-          # go list -mod=mod -u -json -m all
-
-      - name: go get
-        run: |
-          go get -u ./...
-          go mod tidy
-          git diff --exit-code go.???
-
-      # - name: go mod vendor
-      #   run: |
-      #     go mod vendor
-      #     git diff --exit-code
+  dependency_updates:
+    name: Dependency Updates
+    uses: atc0005/shared-project-resources/.github/workflows/dependency-updates.yml@master


### PR DESCRIPTION
Refactor workflow file by moving bulk of Go Module and Dependencies job content to separate files. We then include those files in the original workflow to retain existing/expected behavior for importing workflows within dependent projects.

The new files are now available for use within dependent projects directly.

refs atc0005/todo#52