### PR TITLE
Explicitly switch from "latest" to specific ver

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -17,7 +17,7 @@ jobs:
     continue-on-error: true
     timeout-minutes: 10
     container:
-      image: ghcr.io/atc0005/go-ci:go-ci-lint-only
+      image: ghcr.io/atc0005/go-ci:go-ci-lint-only-v0.7.9-0-gdf9564d3
 
     steps:
       - name: Check out code

--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/atc0005/go-ci:go-ci-lint-only
+      image: ghcr.io/atc0005/go-ci:go-ci-lint-only-v0.7.9-0-gdf9564d3
 
     steps:
       - name: Check out code
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/atc0005/go-ci:go-ci-lint-only
+      image: ghcr.io/atc0005/go-ci:go-ci-lint-only-v0.7.9-0-gdf9564d3
 
     steps:
       - name: Check out code

--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -27,7 +27,7 @@ jobs:
           - container-image: "go-ci-unstable"
             experimental: true
     container:
-      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}"
+      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-v0.7.9-0-gdf9564d3"
 
     steps:
       - name: Check out code
@@ -62,7 +62,7 @@ jobs:
         container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
 
     container:
-      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}"
+      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-v0.7.9-0-gdf9564d3"
 
     steps:
       - name: Check out code
@@ -81,7 +81,7 @@ jobs:
         container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
 
     container:
-      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}"
+      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-v0.7.9-0-gdf9564d3"
 
     steps:
       - name: Print go version

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 10
     container:
       # Use (lightly touched) mirror of current "vanilla" upstream golang image
-      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build"
+      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build-v0.7.9-0-gdf9564d3"
 
     steps:
       - name: Print go version
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 55
     container:
       # Use (lightly touched) mirror of current "vanilla" upstream golang image
-      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build"
+      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build-v0.7.9-0-gdf9564d3"
 
     steps:
       - name: Print go version

--- a/.github/workflows/quick-validation.yml
+++ b/.github/workflows/quick-validation.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/atc0005/go-ci:go-ci-lint-only
+      image: ghcr.io/atc0005/go-ci:go-ci-lint-only-v0.7.9-0-gdf9564d3
 
     steps:
       - name: Check out code

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/atc0005/go-ci:go-ci-lint-only
+      image: ghcr.io/atc0005/go-ci:go-ci-lint-only-v0.7.9-0-gdf9564d3
 
     steps:
       - name: Check out code


### PR DESCRIPTION
After the atc0005/go-ci v0.7.10 release various CI jobs begain failing. Here we explicitly rollback to the v0.7.9 release tag to test whether that resolves the issue.