### PR TITLE
Explicitly use specific release version

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -8,6 +8,21 @@
 on:
   workflow_call:
 
+# https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow
+env:
+  # https://github.com/atc0005/go-ci/issues/848
+  #
+  # Confirmed working:
+  # GO_CI_IMG_RELEASE_VER: "v0.7.9-0-gdf9564d3"
+  #
+  # Without workarounds will fail (git package security updates):
+  # GO_CI_IMG_RELEASE_VER: "v0.7.10-0-gcc0a2418"
+  #
+  # Use latest atc0005/go-ci image releases, trusting that workarounds applied
+  # in this workflow are sufficient to resolve any issues not handled in the
+  # image itself:
+  GO_CI_IMG_RELEASE_VER: "latest"
+
 jobs:
   dependency_updates:
     name: Look for available minor or patch releases
@@ -17,7 +32,7 @@ jobs:
     continue-on-error: true
     timeout-minutes: 10
     container:
-      image: ghcr.io/atc0005/go-ci:go-ci-lint-only-v0.7.9-0-gdf9564d3
+      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-${{ env.GO_CI_IMG_RELEASE_VER }}"
 
     steps:
       - name: Check out code

--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -8,13 +8,28 @@
 on:
   workflow_call:
 
+# https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow
+env:
+  # https://github.com/atc0005/go-ci/issues/848
+  #
+  # Confirmed working:
+  # GO_CI_IMG_RELEASE_VER: "v0.7.9-0-gdf9564d3"
+  #
+  # Without workarounds will fail (git package security updates):
+  # GO_CI_IMG_RELEASE_VER: "v0.7.10-0-gcc0a2418"
+  #
+  # Use latest atc0005/go-ci image releases, trusting that workarounds applied
+  # in this workflow are sufficient to resolve any issues not handled in the
+  # image itself:
+  GO_CI_IMG_RELEASE_VER: "latest"
+
 jobs:
   go_mod_changes:
     name: Look for missing go.mod changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/atc0005/go-ci:go-ci-lint-only-v0.7.9-0-gdf9564d3
+      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-${{ env.GO_CI_IMG_RELEASE_VER }}"
 
     steps:
       - name: Check out code
@@ -30,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/atc0005/go-ci:go-ci-lint-only-v0.7.9-0-gdf9564d3
+      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-${{ env.GO_CI_IMG_RELEASE_VER }}"
 
     steps:
       - name: Check out code

--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -8,6 +8,21 @@
 on:
   workflow_call:
 
+# https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow
+env:
+  # https://github.com/atc0005/go-ci/issues/848
+  #
+  # Confirmed working:
+  # GO_CI_IMG_RELEASE_VER: "v0.7.9-0-gdf9564d3"
+  #
+  # Without workarounds will fail (git package security updates):
+  # GO_CI_IMG_RELEASE_VER: "v0.7.10-0-gcc0a2418"
+  #
+  # Use latest atc0005/go-ci image releases, trusting that workarounds applied
+  # in this workflow are sufficient to resolve any issues not handled in the
+  # image itself:
+  GO_CI_IMG_RELEASE_VER: "latest"
+
 jobs:
   lint_code:
     name: Lint codebase
@@ -27,7 +42,7 @@ jobs:
           - container-image: "go-ci-unstable"
             experimental: true
     container:
-      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-v0.7.9-0-gdf9564d3"
+      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-${{ env.GO_CI_IMG_RELEASE_VER }}"
 
     steps:
       - name: Check out code
@@ -62,7 +77,7 @@ jobs:
         container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
 
     container:
-      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-v0.7.9-0-gdf9564d3"
+      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-${{ env.GO_CI_IMG_RELEASE_VER }}"
 
     steps:
       - name: Check out code
@@ -81,7 +96,7 @@ jobs:
         container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
 
     container:
-      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-v0.7.9-0-gdf9564d3"
+      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-${{ env.GO_CI_IMG_RELEASE_VER }}"
 
     steps:
       - name: Print go version

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -15,6 +15,21 @@ on:
         required: false
         type: boolean
 
+# https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow
+env:
+  # https://github.com/atc0005/go-ci/issues/848
+  #
+  # Confirmed working:
+  # GO_CI_IMG_RELEASE_VER: "v0.7.9-0-gdf9564d3"
+  #
+  # Without workarounds will fail (git package security updates):
+  # GO_CI_IMG_RELEASE_VER: "v0.7.10-0-gcc0a2418"
+  #
+  # Use latest atc0005/go-ci image releases, trusting that workarounds applied
+  # in this workflow are sufficient to resolve any issues not handled in the
+  # image itself:
+  GO_CI_IMG_RELEASE_VER: "latest"
+
 jobs:
   lint_code_with_makefile:
     name: Lint codebase using Makefile
@@ -23,7 +38,7 @@ jobs:
     timeout-minutes: 10
     container:
       # Use (lightly touched) mirror of current "vanilla" upstream golang image
-      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build-v0.7.9-0-gdf9564d3"
+      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build-${{ env.GO_CI_IMG_RELEASE_VER }}"
 
     steps:
       - name: Print go version
@@ -64,7 +79,7 @@ jobs:
     timeout-minutes: 55
     container:
       # Use (lightly touched) mirror of current "vanilla" upstream golang image
-      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build-v0.7.9-0-gdf9564d3"
+      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build-${{ env.GO_CI_IMG_RELEASE_VER }}"
 
     steps:
       - name: Print go version

--- a/.github/workflows/lint-project-files.yml
+++ b/.github/workflows/lint-project-files.yml
@@ -10,6 +10,21 @@ on:
     types: [opened, synchronize]
   workflow_call:
 
+# https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow
+env:
+  # https://github.com/atc0005/go-ci/issues/848
+  #
+  # Confirmed working:
+  # GO_CI_IMG_RELEASE_VER: "v0.7.9-0-gdf9564d3"
+  #
+  # Without workarounds will fail (git package security updates):
+  # GO_CI_IMG_RELEASE_VER: "v0.7.10-0-gcc0a2418"
+  #
+  # Use latest atc0005/go-ci image releases, trusting that workarounds applied
+  # in this workflow are sufficient to resolve any issues not handled in the
+  # image itself:
+  GO_CI_IMG_RELEASE_VER: "latest"
+
 jobs:
   lint_markdown:
     name: Lint Markdown files

--- a/.github/workflows/quick-validation.yml
+++ b/.github/workflows/quick-validation.yml
@@ -8,13 +8,28 @@
 on:
   workflow_call:
 
+# https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow
+env:
+  # https://github.com/atc0005/go-ci/issues/848
+  #
+  # Confirmed working:
+  # GO_CI_IMG_RELEASE_VER: "v0.7.9-0-gdf9564d3"
+  #
+  # Without workarounds will fail (git package security updates):
+  # GO_CI_IMG_RELEASE_VER: "v0.7.10-0-gcc0a2418"
+  #
+  # Use latest atc0005/go-ci image releases, trusting that workarounds applied
+  # in this workflow are sufficient to resolve any issues not handled in the
+  # image itself:
+  GO_CI_IMG_RELEASE_VER: "latest"
+
 jobs:
   lint_and_test_code:
     name: Lint and test using latest stable container
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/atc0005/go-ci:go-ci-lint-only-v0.7.9-0-gdf9564d3
+      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-${{ env.GO_CI_IMG_RELEASE_VER }}"
 
     steps:
       - name: Check out code

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -8,6 +8,21 @@
 on:
   workflow_call:
 
+# https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow
+env:
+  # https://github.com/atc0005/go-ci/issues/848
+  #
+  # Confirmed working:
+  # GO_CI_IMG_RELEASE_VER: "v0.7.9-0-gdf9564d3"
+  #
+  # Without workarounds will fail (git package security updates):
+  # GO_CI_IMG_RELEASE_VER: "v0.7.10-0-gcc0a2418"
+  #
+  # Use latest atc0005/go-ci image releases, trusting that workarounds applied
+  # in this workflow are sufficient to resolve any issues not handled in the
+  # image itself:
+  GO_CI_IMG_RELEASE_VER: "latest"
+
 jobs:
   codeql:
     name: CodeQL
@@ -68,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/atc0005/go-ci:go-ci-lint-only-v0.7.9-0-gdf9564d3
+      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-${{ env.GO_CI_IMG_RELEASE_VER }}"
 
     steps:
       - name: Check out code


### PR DESCRIPTION
Swap from hard-coded version (used as a workaround) of images from the atc0005/go-ci project to using a GitHub Actions Workflow variable set at the top of each workflow.

As of this commit we've switched back to the `latest` tag for each image, but we can now easily switch all atc0005/go-ci images to a specific version for testing purposes in the future.

refs GH-56
refs https://github.com/atc0005/go-ci/issues/848