### PR TITLE
Explicitly trust CWD by Git after checkout

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -38,6 +38,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.3.0
 
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
+
       # Provided for contrast. Will likely remove this one at some point.
       - name: go list
         run: |

--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -35,6 +35,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.3.0
 
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
+
       - name: go mod tidy
         run: |
           go mod tidy -v
@@ -50,6 +61,17 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3.3.0
+
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
 
       - name: go mod vendor
         run: |

--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -48,6 +48,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.3.0
 
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
+
       - name: Remove repo-provided golangci-lint config file
         run: |
           # Remove the copy of the config file bundled with the repo/code so
@@ -83,6 +94,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.3.0
 
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
+
       - name: Run all tests
         run: go test -mod=vendor -v ./...
 
@@ -104,6 +126,17 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v3.3.0
+
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
 
       - name: Build using vendored dependencies
         # NOTE: This will fail if there is a doc.go file in the project root

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -47,6 +47,17 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3.3.0
 
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
+
       # bsdmainutils provides "column" which is used by the Makefile
       - name: Install Ubuntu packages
         run: apt-get update && apt-get install -y --no-install-recommends make gcc bsdmainutils
@@ -95,6 +106,17 @@ jobs:
         with:
           # Needed in order to retrieve tags for use with go generate
           fetch-depth: 0
+
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
 
       - name: Install Ubuntu packages (standard set)
         if: ${{ inputs.os-dependencies == '' }}

--- a/.github/workflows/lint-project-files.yml
+++ b/.github/workflows/lint-project-files.yml
@@ -48,6 +48,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.3.0
 
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
+
       - name: Run Markdown linting tools
         # The `.markdownlint.yml` file specifies config settings for this
         # linter, including which linting rules to ignore.
@@ -69,6 +80,17 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3.3.0
+
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
 
       - name: Run hadolint against any Dockerfiles
         if: hashFiles('**/Dockerfile') != ''

--- a/.github/workflows/lint-project-files.yml
+++ b/.github/workflows/lint-project-files.yml
@@ -88,9 +88,9 @@ jobs:
       # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
       # https://github.com/actions/runner-images/issues/6775
       # https://github.com/actions/checkout/issues/766
-      - name: Mark the current working directory as a safe directory in git
-        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        run: git config --global --add safe.directory "${PWD}"
+      #- name: Mark the current working directory as a safe directory in git
+      #  # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      #  run: git config --global --add safe.directory "${PWD}"
 
       - name: Run hadolint against any Dockerfiles
         if: hashFiles('**/Dockerfile') != ''

--- a/.github/workflows/quick-validation.yml
+++ b/.github/workflows/quick-validation.yml
@@ -35,6 +35,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.3.0
 
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
+
       - name: Remove repo-provided golangci-lint config file
         run: |
           # Remove the copy of the config file bundled with the repo/code so

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -46,6 +46,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3.3.0
 
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2.2.3
@@ -88,6 +99,17 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3.3.0
+
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
 
       - name: Analyze source code
         run: |


### PR DESCRIPTION
Work around potential "dubious ownership" complaints from Git regarding the workspace used by GitHub task runners by explicitly marking the current working
directory as trusted after checking out content from the repo.

Since we're not sharing that space with other user accounts this should be a safe assumption to make.

refs https://github.com/atc0005/go-ci/issues/848