### PR TITLE
Attempt to fix variable ref syntax

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -32,7 +32,7 @@ jobs:
     continue-on-error: true
     timeout-minutes: 10
     container:
-      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-${{ env.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-$GO_CI_IMG_RELEASE_VER"
 
     steps:
       - name: Check out code

--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-${{ env.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-$GO_CI_IMG_RELEASE_VER"
 
     steps:
       - name: Check out code
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-${{ env.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-$GO_CI_IMG_RELEASE_VER"
 
     steps:
       - name: Check out code

--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -42,7 +42,7 @@ jobs:
           - container-image: "go-ci-unstable"
             experimental: true
     container:
-      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-${{ env.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-$GO_CI_IMG_RELEASE_VER"
 
     steps:
       - name: Check out code
@@ -88,7 +88,7 @@ jobs:
         container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
 
     container:
-      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-${{ env.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-$GO_CI_IMG_RELEASE_VER"
 
     steps:
       - name: Check out code
@@ -118,7 +118,7 @@ jobs:
         container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
 
     container:
-      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-${{ env.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-$GO_CI_IMG_RELEASE_VER"
 
     steps:
       - name: Print go version

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 10
     container:
       # Use (lightly touched) mirror of current "vanilla" upstream golang image
-      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build-${{ env.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build-$GO_CI_IMG_RELEASE_VER"
 
     steps:
       - name: Print go version
@@ -90,7 +90,7 @@ jobs:
     timeout-minutes: 55
     container:
       # Use (lightly touched) mirror of current "vanilla" upstream golang image
-      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build-${{ env.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build-$GO_CI_IMG_RELEASE_VER"
 
     steps:
       - name: Print go version

--- a/.github/workflows/quick-validation.yml
+++ b/.github/workflows/quick-validation.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-${{ env.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-$GO_CI_IMG_RELEASE_VER"
 
     steps:
       - name: Check out code

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-${{ env.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-$GO_CI_IMG_RELEASE_VER"
 
     steps:
       - name: Check out code


### PR DESCRIPTION
After merging 601c7d4d55e08313b083fa0469ca2a0967b51e69 CI jobs in other projects began failing with errors such as:

"Unrecognized named-value: 'env'."

Attempt to use alternate syntax noted in the GitHub Actions documentation to see if that resolves the problem.

refs GH-57
refs https://docs.github.com/en/actions/learn-github-actions/variables#using-the-vars-context-to-access-configuration-variable-values