### PR TITLE
Using latest tag for all container images

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -8,21 +8,6 @@
 on:
   workflow_call:
 
-# https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow
-env:
-  # https://github.com/atc0005/go-ci/issues/848
-  #
-  # Confirmed working:
-  # GO_CI_IMG_RELEASE_VER: "v0.7.9-0-gdf9564d3"
-  #
-  # Without workarounds will fail (git package security updates):
-  # GO_CI_IMG_RELEASE_VER: "v0.7.10-0-gcc0a2418"
-  #
-  # Use latest atc0005/go-ci image releases, trusting that workarounds applied
-  # in this workflow are sufficient to resolve any issues not handled in the
-  # image itself:
-  GO_CI_IMG_RELEASE_VER: "latest"
-
 jobs:
   dependency_updates:
     name: Look for available minor or patch releases
@@ -32,7 +17,7 @@ jobs:
     continue-on-error: true
     timeout-minutes: 10
     container:
-      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-${{ vars.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only"
 
     steps:
       - name: Check out code

--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -8,28 +8,13 @@
 on:
   workflow_call:
 
-# https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow
-env:
-  # https://github.com/atc0005/go-ci/issues/848
-  #
-  # Confirmed working:
-  # GO_CI_IMG_RELEASE_VER: "v0.7.9-0-gdf9564d3"
-  #
-  # Without workarounds will fail (git package security updates):
-  # GO_CI_IMG_RELEASE_VER: "v0.7.10-0-gcc0a2418"
-  #
-  # Use latest atc0005/go-ci image releases, trusting that workarounds applied
-  # in this workflow are sufficient to resolve any issues not handled in the
-  # image itself:
-  GO_CI_IMG_RELEASE_VER: "latest"
-
 jobs:
   go_mod_changes:
     name: Look for missing go.mod changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-${{ vars.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only"
 
     steps:
       - name: Check out code
@@ -56,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-${{ vars.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only"
 
     steps:
       - name: Check out code

--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -8,21 +8,6 @@
 on:
   workflow_call:
 
-# https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow
-env:
-  # https://github.com/atc0005/go-ci/issues/848
-  #
-  # Confirmed working:
-  # GO_CI_IMG_RELEASE_VER: "v0.7.9-0-gdf9564d3"
-  #
-  # Without workarounds will fail (git package security updates):
-  # GO_CI_IMG_RELEASE_VER: "v0.7.10-0-gcc0a2418"
-  #
-  # Use latest atc0005/go-ci image releases, trusting that workarounds applied
-  # in this workflow are sufficient to resolve any issues not handled in the
-  # image itself:
-  GO_CI_IMG_RELEASE_VER: "latest"
-
 jobs:
   lint_code:
     name: Lint codebase
@@ -42,7 +27,7 @@ jobs:
           - container-image: "go-ci-unstable"
             experimental: true
     container:
-      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-${{ vars.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}"
 
     steps:
       - name: Check out code
@@ -88,7 +73,7 @@ jobs:
         container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
 
     container:
-      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-${{ vars.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}"
 
     steps:
       - name: Check out code
@@ -118,7 +103,7 @@ jobs:
         container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
 
     container:
-      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}-${{ vars.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}"
 
     steps:
       - name: Print go version

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -15,21 +15,6 @@ on:
         required: false
         type: boolean
 
-# https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow
-env:
-  # https://github.com/atc0005/go-ci/issues/848
-  #
-  # Confirmed working:
-  # GO_CI_IMG_RELEASE_VER: "v0.7.9-0-gdf9564d3"
-  #
-  # Without workarounds will fail (git package security updates):
-  # GO_CI_IMG_RELEASE_VER: "v0.7.10-0-gcc0a2418"
-  #
-  # Use latest atc0005/go-ci image releases, trusting that workarounds applied
-  # in this workflow are sufficient to resolve any issues not handled in the
-  # image itself:
-  GO_CI_IMG_RELEASE_VER: "latest"
-
 jobs:
   lint_code_with_makefile:
     name: Lint codebase using Makefile
@@ -38,7 +23,7 @@ jobs:
     timeout-minutes: 10
     container:
       # Use (lightly touched) mirror of current "vanilla" upstream golang image
-      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build-${{ vars.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build"
 
     steps:
       - name: Print go version
@@ -90,7 +75,7 @@ jobs:
     timeout-minutes: 55
     container:
       # Use (lightly touched) mirror of current "vanilla" upstream golang image
-      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build-${{ vars.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build"
 
     steps:
       - name: Print go version

--- a/.github/workflows/quick-validation.yml
+++ b/.github/workflows/quick-validation.yml
@@ -8,28 +8,13 @@
 on:
   workflow_call:
 
-# https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow
-env:
-  # https://github.com/atc0005/go-ci/issues/848
-  #
-  # Confirmed working:
-  # GO_CI_IMG_RELEASE_VER: "v0.7.9-0-gdf9564d3"
-  #
-  # Without workarounds will fail (git package security updates):
-  # GO_CI_IMG_RELEASE_VER: "v0.7.10-0-gcc0a2418"
-  #
-  # Use latest atc0005/go-ci image releases, trusting that workarounds applied
-  # in this workflow are sufficient to resolve any issues not handled in the
-  # image itself:
-  GO_CI_IMG_RELEASE_VER: "latest"
-
 jobs:
   lint_and_test_code:
     name: Lint and test using latest stable container
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-${{ vars.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only"
 
     steps:
       - name: Check out code

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -8,21 +8,6 @@
 on:
   workflow_call:
 
-# https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow
-env:
-  # https://github.com/atc0005/go-ci/issues/848
-  #
-  # Confirmed working:
-  # GO_CI_IMG_RELEASE_VER: "v0.7.9-0-gdf9564d3"
-  #
-  # Without workarounds will fail (git package security updates):
-  # GO_CI_IMG_RELEASE_VER: "v0.7.10-0-gcc0a2418"
-  #
-  # Use latest atc0005/go-ci image releases, trusting that workarounds applied
-  # in this workflow are sufficient to resolve any issues not handled in the
-  # image itself:
-  GO_CI_IMG_RELEASE_VER: "latest"
-
 jobs:
   codeql:
     name: CodeQL
@@ -94,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only-${{ vars.GO_CI_IMG_RELEASE_VER }}"
+      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only"
 
     steps:
       - name: Check out code


### PR DESCRIPTION
Giving up on using per-workflow variable (syntax does not seem to be supported) and going back to previous behavior of using the "latest" tag for each image.

In the future I may opt to setup per-repo variables and use that value.

https://docs.github.com/en/actions/learn-github-actions/variables#defining-configuration-variables-for-multiple-workflows