### PR TITLE
Add importable workflows for scheduled tasks

### DIFF
--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -1,0 +1,36 @@
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/shared-project-resources
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# Purpose: This importable workflow is intended to act as a wrapper or bucket
+# for tasks that are run on a monthly schedule. This can be used to run jobs
+# that are more intensive/expensive than would be warranted to run on every
+# pull request or a more frequent (e.g., weekly) schedule.
+
+on:
+  workflow_call:
+    # Default for all inputs is off/false, but overridable from the calling
+    # workflow.
+    inputs:
+      os-dependencies:
+        required: false
+        type: string
+      gogeninstall:
+        required: false
+        type: boolean
+
+jobs:
+  lint_and_build_using_ci_matrix:
+    name: CI matrix
+    uses: atc0005/shared-project-resources/.github/workflows/lint-and-build-using-ci-matrix.yml@master
+
+  lint_and_build_using_makefile:
+    name: Makefile
+    with:
+      # Pass on any values specified by the importing workflow.
+      os-dependencies: ${{ inputs.os-dependencies }}
+      gogeninstall: ${{ inputs.gogeninstall }}
+    uses: atc0005/shared-project-resources/.github/workflows/lint-and-build-using-make.yml@master

--- a/.github/workflows/scheduled-weekly.yml
+++ b/.github/workflows/scheduled-weekly.yml
@@ -1,0 +1,32 @@
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/shared-project-resources
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# Purpose: This importable workflow is intended to act as a wrapper or bucket
+# for tasks that are run on a weekly schedule. This can be used to run jobs
+# that are more intensive/expensive than would be warranted to run on every
+# pull request OR jobs that should be re-run periodically due to potentially
+# updated data files (e.g., vulnerability scanning).
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    name: Lint
+    uses: atc0005/shared-project-resources/.github/workflows/lint-project-files.yml@master
+
+  vulnerability:
+    name: Vulnerability
+    uses: atc0005/shared-project-resources/.github/workflows/vulnerability-analysis.yml@master
+
+  go_mod_validation:
+    name: Go Module Validation
+    uses: atc0005/shared-project-resources/.github/workflows/go-mod-validation.yml@master
+
+  # dependency_updates:
+  #   name: Dependency Updates
+  #   uses: atc0005/shared-project-resources/.github/workflows/dependency-updates.yml@master


### PR DESCRIPTION
- scheduled-weekly.yml
- scheduled-monthly.yml

The intent is to provide importable workflows for tasks that should be run periodically on set schedules (and managed in one location vs maintaining separately for each project).

fixes GH-68