### PR TITLE
Update go-ci images to reflect upstream changes

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -17,7 +17,7 @@ jobs:
     continue-on-error: true
     timeout-minutes: 10
     container:
-      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only"
+      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build"
 
     steps:
       - name: Check out code

--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only"
+      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build"
 
     steps:
       - name: Check out code
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only"
+      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build"
 
     steps:
       - name: Check out code

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -64,6 +64,8 @@ jobs:
       - name: Run Go linting tools using project Makefile
         run: make linting
 
+  # TODO: Move this to the scheduled-monthly.yml file *after* a sufficient
+  # number of projects have been updated to provide a `quick` Makefile recipe.
   build_code_with_makefile_all_recipe:
     name: Build codebase using Makefile all recipe
     runs-on: ubuntu-latest

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -79,7 +79,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: "ghcr.io/atc0005/go-ci:go-ci-lint-only"
+      # NOTE: govulncheck is bundled within this image
+      image: "ghcr.io/atc0005/go-ci:go-ci-stable"
 
     steps:
       - name: Check out code


### PR DESCRIPTION
v0.8.0 reworked image names, dropped linter-only images, etc.

This set of changes updates the shared CI workflows to use the updated image names.