### PR TITLE
Tweak step name to emphasize it is deprecated

### DIFF
--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -113,7 +113,7 @@ jobs:
         run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.os-dependencies }}
 
       # DEPRECATED; replacing with depsinstall Makefile recipe (broader scope)
-      - name: Install go generate dependencies (if requested)
+      - name: Install go generate dependencies (deprecated)
         if: inputs.gogeninstall
         run: |
           echo "The gogeninstall input is deprecated and will be removed soon."


### PR DESCRIPTION
The "if requested" suffix worked well before when it was an optional, rarely requested task, but now that it is going away that suffix does not communicate that it should not be used any longer.