### PR TITLE
Remove gogeninstall refs from monthly workflow

### DIFF
--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -18,9 +18,6 @@ on:
       os-dependencies:
         required: false
         type: string
-      gogeninstall:
-        required: false
-        type: boolean
 
 jobs:
   lint_and_build_using_ci_matrix:
@@ -32,5 +29,4 @@ jobs:
     with:
       # Pass on any values specified by the importing workflow.
       os-dependencies: ${{ inputs.os-dependencies }}
-      gogeninstall: ${{ inputs.gogeninstall }}
     uses: atc0005/shared-project-resources/.github/workflows/lint-and-build-using-make.yml@master


### PR DESCRIPTION
This was missed with recent cleanup work.

refs GH-71