### PR TITLE
Add `on.push` hook to vulnerability-analysis GHAW

### DIFF
--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   codeql:
+    # Skip if this workflow is used within the shared resources project
+    if: github.repository != 'atc0005/shared-project-resources'
+
     name: CodeQL
     runs-on: ubuntu-latest
     # Default: 360 minutes
@@ -73,6 +76,9 @@ jobs:
         uses: github/codeql-action/analyze@v2.2.7
 
   govulncheck:
+    # Skip if this workflow is used within the shared resources project
+    if: github.repository != 'atc0005/shared-project-resources'
+
     # https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck
     # https://github.com/golang/vuln
     # https://github.com/atc0005/go-ci/issues/734

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -7,6 +7,7 @@
 
 on:
   workflow_call:
+  push:
 
 jobs:
   codeql:


### PR DESCRIPTION
The CodeQL Code Scanning feature is flagging workflows importing this one as missing that event hook as it needs it to perform before/after analysis of base branch changes.

We explicitly exclude running that job as well as the govulncheck job from within this repo so that it only runs within dependent repos.