### PR TITLE
Remove on.push event hook from vuln analysis GHAW

### DIFF
--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -7,13 +7,9 @@
 
 on:
   workflow_call:
-  push:
 
 jobs:
   codeql:
-    # Skip if this workflow is used within the shared resources project
-    if: github.repository != 'atc0005/shared-project-resources'
-
     name: CodeQL
     runs-on: ubuntu-latest
     # Default: 360 minutes
@@ -76,9 +72,6 @@ jobs:
         uses: github/codeql-action/analyze@v2.2.7
 
   govulncheck:
-    # Skip if this workflow is used within the shared resources project
-    if: github.repository != 'atc0005/shared-project-resources'
-
     # https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck
     # https://github.com/golang/vuln
     # https://github.com/atc0005/go-ci/issues/734


### PR DESCRIPTION
That change did not resolve the issue with dependent projects. Instead, the on.push event hook will need to be added to the workflows importing this one.