### PR TITLE
Disable structslop linter

### DIFF
--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -44,10 +44,12 @@ jobs:
         # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
         run: git config --global --add safe.directory "${PWD}"
 
-      - name: Run orijtech/structslop
-        run: |
-          echo "structslop version $(go version -m $(which structslop) | awk '$1 == "mod" { print $3 }')"
-          structslop ./...
+      # DISABLED until https://github.com/atc0005/go-ci/issues/962 is resolved
+      #
+      # - name: Run orijtech/structslop
+      #   run: |
+      #     echo "structslop version $(go version -m $(which structslop) | awk '$1 == "mod" { print $3 }')"
+      #     structslop ./...
 
       - name: Run orijtech/tickeryzer
         run: |


### PR DESCRIPTION
Disabling until Go 1.20 compatibility issue can be resolved.

refs https://github.com/atc0005/go-ci/issues/962