### PR TITLE
Specify go-ci container for CodeQL job

### DIFF
--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -14,6 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     # Default: 360 minutes
     timeout-minutes: 10
+    container:
+      # NOTE: CodeQL requires a Go version equal to or greater than the
+      # version specified in the project's go.mod file. We use a container
+      # image to provide this version of Go.
+      image: "ghcr.io/atc0005/go-ci:go-ci-stable"
+
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Per CodeQL job settings the Go version in the environment must be greater than or equal to the version listed in the project's go.mod file.

Attempt to use the latest go-ci stable container for this purpose.