### PR TITLE
Re-enable orijtech/structslop linter

### DIFF
--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -41,12 +41,10 @@ jobs:
         # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
         run: git config --global --add safe.directory "${PWD}"
 
-      # DISABLED until https://github.com/atc0005/go-ci/issues/962 is resolved
-      #
-      # - name: Run orijtech/structslop
-      #   run: |
-      #     echo "structslop version $(go version -m $(which structslop) | awk '$1 == "mod" { print $3 }')"
-      #     structslop ./...
+      - name: Run orijtech/structslop
+        run: |
+          echo "structslop version $(go version -m $(which structslop) | awk '$1 == "mod" { print $3 }')"
+          structslop ./...
 
       - name: Run orijtech/tickeryzer
         run: |


### PR DESCRIPTION
Enable now that Go 1.20 compatibility issue has been resolved.

- refs atc0005/go-ci#962
- refs atc0005/shared-project-resources#90