### PR TITLE
Limit `make all` recipe calls to monthly workflow

### DIFF
--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -11,6 +11,9 @@ on:
       os-dependencies:
         required: false
         type: string
+      build-all:
+        required: false
+        type: boolean
 
 jobs:
   lint_code_with_makefile:
@@ -116,10 +119,11 @@ jobs:
       - name: Build using project Makefile "quick" recipe
         run: make quick
 
-  # TODO: Move this to the scheduled-monthly.yml file *after* a sufficient
-  # number of projects have been updated to provide a `quick` Makefile recipe.
+  # The `make all` recipe can be expensive, so we disable it by default
+  # and enable it only by explicit request (e.g., monthly scheduled job).
   build_code_with_makefile_all_recipe:
     name: Build codebase using Makefile all recipe
+    if: inputs.build-all
     runs-on: ubuntu-latest
     # Default: 360 minutes
     #

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -29,4 +29,8 @@ jobs:
     with:
       # Pass on any values specified by the importing workflow.
       os-dependencies: ${{ inputs.os-dependencies }}
+
+      # The `make all` recipe can be expensive, so we disable it by default
+      # and enable it here as part of a scheduled monthly job.
+      build-all: true
     uses: atc0005/shared-project-resources/.github/workflows/lint-and-build-using-make.yml@master


### PR DESCRIPTION
- add new `build-all` input to act as a toggle for the `Build codebase using Makefile all recipe` job
- explicitly set this input for the `Makefile` job in the scheduled monthly job workflow

refs GH-117