### PR TITLE
Set `make all` recipe as required

### DIFF
--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -67,9 +67,10 @@ jobs:
   build_code_with_makefile_quick_recipe:
     name: Build codebase using Makefile quick recipe (try)
 
-    # NOTE: This recipe does not yet exist for many of the projects using this
-    # workflow, so mark it as "OK" to fail without failing CI jobs as a whole.
-    continue-on-error: true
+    # NOTE: This recipe should now exist for the majority of projects using
+    # these (importable) workflows. We reverse the "it is OK to fail" setting
+    # in order to surface any projects not yet updated to provide this recipe.
+    continue-on-error: false
 
     runs-on: ubuntu-latest
     # Default: 360 minutes


### PR DESCRIPTION
Now that the majority of dependent projects provide this recipe we can switch them over from requiring `make all` to `make quick` for PR CI executions.

Any projects not yet providing a `quick` recipe can be updated to do so.

refs GH-5