### PR TITLE
Add `podman-release-build` recipe to monthly flow

### DIFF
--- a/.github/workflows/container-builds.yml
+++ b/.github/workflows/container-builds.yml
@@ -11,6 +11,9 @@ on:
       build-packages:
         required: false
         type: boolean
+      build-podman-release:
+        required: false
+        type: boolean
 
 jobs:
   build_packages_via_makefile:
@@ -46,3 +49,27 @@ jobs:
       - name: Build packages
         run: make packages
 
+  podman_release_build_via_makefile:
+    name: Release build using Podman and Makefile
+    if: ${{ inputs.build-podman-release }}
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3.5.2
+
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
+
+      - name: Use Podman to generate release build assets
+        run: make podman-release-build

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -19,6 +19,17 @@ on:
         required: false
         type: string
 
+      # NOTE:
+      #
+      # We explicitly set values in this workflow for workflows that we import
+      # and do not yet use these, but we stub these out for later use.
+      build-packages:
+        required: false
+        type: boolean
+      build-podman-release:
+        required: false
+        type: boolean
+
 jobs:
   lint_and_build_using_ci_matrix:
     name: CI matrix
@@ -36,9 +47,17 @@ jobs:
     uses: atc0005/shared-project-resources/.github/workflows/lint-and-build-using-make.yml@master
 
   build_packages_using_container:
-    name: Build packages
+    name: Build packages using container
     with:
       # TODO: Consider passing this from the calling/importing workflow
       # instead of explicitly enabling here.
       build-packages: true
+    uses: atc0005/shared-project-resources/.github/workflows/container-builds.yml@master
+
+  build_release_assets_using_container:
+    name: Build release assets using container
+    with:
+      # TODO: Consider passing this from the calling/importing workflow
+      # instead of explicitly enabling here.
+      build-podman-release: true
     uses: atc0005/shared-project-resources/.github/workflows/container-builds.yml@master


### PR DESCRIPTION
Add new workflow jobs to call `podman-release-build` Makefile recipe as monthly task.

Also, add inputs to importable monthly workflow for later use; we do not yet reference the inputs in the monthly workflow but will need to do so when we begin to provide those values from dependent projects.

fixes GH-47