### PR TITLE
Update container builds to use full fetch depth

### DIFF
--- a/.github/workflows/container-builds.yml
+++ b/.github/workflows/container-builds.yml
@@ -57,8 +57,12 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - name: Check out code into the Go module directory
+      - name: Check out code (full history)
         uses: actions/checkout@v3.5.3
+        with:
+          # Full history is needed to allow listing tags via build tooling
+          # (e.g., go-winres, git-describe-semver)
+          fetch-depth: 0
 
       # Mark the current working directory as a safe directory in git to
       # resolve "dubious ownership" complaints.


### PR DESCRIPTION
This is needed to provide git tags to build tooling.