### PR TITLE
Update container builds to use longer timeout

### DIFF
--- a/.github/workflows/container-builds.yml
+++ b/.github/workflows/container-builds.yml
@@ -54,7 +54,7 @@ jobs:
     if: ${{ inputs.build-podman-release }}
     runs-on: ubuntu-latest
     # Default: 360 minutes
-    timeout-minutes: 20
+    timeout-minutes: 45
 
     steps:
       - name: Check out code (full history)


### PR DESCRIPTION
Adjust from 20 minutes to 45 minutes to account for longer build times during what it believed to be CI resource contention.