### PR TITLE
Split container builds workflow

### DIFF
--- a/.github/workflows/container-builds-packages.yml
+++ b/.github/workflows/container-builds-packages.yml
@@ -11,9 +11,7 @@ on:
       build-packages:
         required: false
         type: boolean
-      build-podman-release:
-        required: false
-        type: boolean
+
 
 jobs:
   build_packages_via_makefile:
@@ -48,32 +46,3 @@ jobs:
 
       - name: Build packages
         run: make packages
-
-  podman_release_build_via_makefile:
-    name: Release build using Podman and Makefile
-    if: ${{ inputs.build-podman-release }}
-    runs-on: ubuntu-latest
-    # Default: 360 minutes
-    timeout-minutes: 45
-
-    steps:
-      - name: Check out code (full history)
-        uses: actions/checkout@v3.5.3
-        with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
-
-      # Mark the current working directory as a safe directory in git to
-      # resolve "dubious ownership" complaints.
-      #
-      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
-      # https://github.com/actions/runner-images/issues/6775
-      # https://github.com/actions/checkout/issues/766
-      - name: Mark the current working directory as a safe directory in git
-        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        run: git config --global --add safe.directory "${PWD}"
-
-      - name: Use Podman to generate release build assets
-        run: make podman-release-build

--- a/.github/workflows/container-builds-release.yml
+++ b/.github/workflows/container-builds-release.yml
@@ -1,0 +1,43 @@
+# Copyright Adam Chalkley
+#
+# https://github.com/atc0005/shared-project-resources
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+on:
+  workflow_call:
+    inputs:
+      build-podman-release:
+        required: false
+        type: boolean
+
+jobs:
+  podman_release_build_via_makefile:
+    name: Release build using Podman and Makefile
+    if: ${{ inputs.build-podman-release }}
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out code (full history)
+        uses: actions/checkout@v3.5.3
+        with:
+          # Full history is needed to allow listing tags via build tooling
+          # (e.g., go-winres, git-describe-semver)
+          fetch-depth: 0
+
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
+
+      - name: Use Podman to generate release build assets
+        run: make podman-release-build

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -18,11 +18,6 @@ on:
       os-dependencies:
         required: false
         type: string
-
-      # NOTE:
-      #
-      # We explicitly set values in this workflow for workflows that we import
-      # and do not yet use these, but we stub these out for later use.
       build-packages:
         required: false
         type: boolean
@@ -53,8 +48,7 @@ jobs:
       # does not support generating release assets directly (e.g., library
       # project).
       build-packages: true
-      build-podman-release: false
-    uses: atc0005/shared-project-resources/.github/workflows/container-builds.yml@master
+    uses: atc0005/shared-project-resources/.github/workflows/container-builds-packages.yml@master
 
   build_release_assets_using_container:
     name: Build release assets using container
@@ -62,6 +56,5 @@ jobs:
       # TODO: Override this from the calling/importing workflow if the project
       # does not support generating release assets directly (e.g., library
       # project).
-      build-packages: false
       build-podman-release: true
-    uses: atc0005/shared-project-resources/.github/workflows/container-builds.yml@master
+    uses: atc0005/shared-project-resources/.github/workflows/container-builds-release.yml@master


### PR DESCRIPTION
Split into separate workflows to allow better control over which jobs are executed. The previous configuration resulted in broken jobs.