### PR TITLE
Try to pass input values directly from importers

### DIFF
--- a/.github/workflows/container-builds-packages.yml
+++ b/.github/workflows/container-builds-packages.yml
@@ -11,7 +11,7 @@ on:
       build-packages:
         required: false
         type: boolean
-
+        default: true
 
 jobs:
   build_packages_via_makefile:

--- a/.github/workflows/container-builds-release.yml
+++ b/.github/workflows/container-builds-release.yml
@@ -11,6 +11,7 @@ on:
       build-podman-release:
         required: false
         type: boolean
+        default: true
 
 jobs:
   podman_release_build_via_makefile:

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -47,7 +47,7 @@ jobs:
       # TODO: Override this from the calling/importing workflow if the project
       # does not support generating release assets directly (e.g., library
       # project).
-      build-packages: true
+      build-packages: ${{ inputs.build-packages }}
     uses: atc0005/shared-project-resources/.github/workflows/container-builds-packages.yml@master
 
   build_release_assets_using_container:
@@ -56,5 +56,5 @@ jobs:
       # TODO: Override this from the calling/importing workflow if the project
       # does not support generating release assets directly (e.g., library
       # project).
-      build-podman-release: true
+      build-podman-release: ${{ inputs.build-podman-release }}
     uses: atc0005/shared-project-resources/.github/workflows/container-builds-release.yml@master


### PR DESCRIPTION
Pass these input values directly:

- build-packages
- build-podman-release

but explicitly set default values in importable container build workflows in case caller does not provide them.

The intent is to run those jobs on the specified schedule unless calling workflows explicitly opt out (e.g., library projects which do not use them).