### PR TITLE
Set input defaults for monthly workflow builds

### DIFF
--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -21,9 +21,11 @@ on:
       build-packages:
         required: false
         type: boolean
+        default: true
       build-podman-release:
         required: false
         type: boolean
+        default: true
 
 jobs:
   lint_and_build_using_ci_matrix:


### PR DESCRIPTION
Setting the default values in the called workflows was not sufficient to enable the builds by default with optional override by callers of this project.

Trying to also set desired defaults in the monthly workflow also.