### PR TITLE
Update timeout for package builds

### DIFF
--- a/.github/workflows/container-builds-packages.yml
+++ b/.github/workflows/container-builds-packages.yml
@@ -19,7 +19,11 @@ jobs:
     if: ${{ inputs.build-packages }}
     runs-on: ubuntu-latest
     # Default: 360 minutes
-    timeout-minutes: 10
+    #
+    # The check-vmware project requires more time than the others, so we use
+    # that projects build time as the max runtime for this workflow for all
+    # projects.
+    timeout-minutes: 55
     container:
       # Use current/stable Go build image as our build environment instead of
       # directly in the runner environment; our build image provides all


### PR DESCRIPTION
Increase from 10 minutes to 55 minutes to account for the long build times needed for the atc0005/check-vmware project.