### PR TITLE
Add job dep to assert PR branch is current

### DIFF
--- a/.github/workflows/container-builds-packages.yml
+++ b/.github/workflows/container-builds-packages.yml
@@ -14,6 +14,27 @@ on:
         default: true
 
 jobs:
+  # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
+  # https://stackoverflow.com/a/76151412/903870
+  # https://github.com/atc0005/shared-project-resources/issues/135
+  assert_pr_branch_is_ahead_of_primary_branch:
+    name: Assert PR branch is ahead of primary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code (full history)
+        uses: actions/checkout@v3.5.3
+        with:
+          # Full history is needed to allow listing tags via build tooling
+          # (e.g., go-winres, git-describe-semver)
+          fetch-depth: 0
+
+      - name: Check if branch is ahead of master
+        run: |
+          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
+          then echo "This branch is not up to date with primary branch";
+          exit 1; fi
+
   build_packages_via_makefile:
     name: Build packages using Makefile
     if: ${{ inputs.build-packages }}

--- a/.github/workflows/container-builds-release.yml
+++ b/.github/workflows/container-builds-release.yml
@@ -14,7 +14,29 @@ on:
         default: true
 
 jobs:
+  # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
+  # https://stackoverflow.com/a/76151412/903870
+  # https://github.com/atc0005/shared-project-resources/issues/135
+  assert_pr_branch_is_ahead_of_primary_branch:
+    name: Assert PR branch is ahead of primary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code (full history)
+        uses: actions/checkout@v3.5.3
+        with:
+          # Full history is needed to allow listing tags via build tooling
+          # (e.g., go-winres, git-describe-semver)
+          fetch-depth: 0
+
+      - name: Check if branch is ahead of master
+        run: |
+          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
+          then echo "This branch is not up to date with primary branch";
+          exit 1; fi
+
   podman_release_build_via_makefile:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Release build using Podman and Makefile
     if: ${{ inputs.build-podman-release }}
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -9,7 +9,29 @@ on:
   workflow_call:
 
 jobs:
+  # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
+  # https://stackoverflow.com/a/76151412/903870
+  # https://github.com/atc0005/shared-project-resources/issues/135
+  assert_pr_branch_is_ahead_of_primary_branch:
+    name: Assert PR branch is ahead of primary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code (full history)
+        uses: actions/checkout@v3.5.3
+        with:
+          # Full history is needed to allow listing tags via build tooling
+          # (e.g., go-winres, git-describe-semver)
+          fetch-depth: 0
+
+      - name: Check if branch is ahead of master
+        run: |
+          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
+          then echo "This branch is not up to date with primary branch";
+          exit 1; fi
+
   dependency_updates:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Look for available minor or patch releases
     runs-on: ubuntu-latest
 

--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -9,7 +9,29 @@ on:
   workflow_call:
 
 jobs:
+  # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
+  # https://stackoverflow.com/a/76151412/903870
+  # https://github.com/atc0005/shared-project-resources/issues/135
+  assert_pr_branch_is_ahead_of_primary_branch:
+    name: Assert PR branch is ahead of primary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code (full history)
+        uses: actions/checkout@v3.5.3
+        with:
+          # Full history is needed to allow listing tags via build tooling
+          # (e.g., go-winres, git-describe-semver)
+          fetch-depth: 0
+
+      - name: Check if branch is ahead of master
+        run: |
+          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
+          then echo "This branch is not up to date with primary branch";
+          exit 1; fi
+
   go_mod_changes:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Look for missing go.mod changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -37,6 +59,7 @@ jobs:
           git diff --exit-code go.mod
 
   go_mod_vendor:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Look for missing vendored dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -9,7 +9,29 @@ on:
   workflow_call:
 
 jobs:
+  # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
+  # https://stackoverflow.com/a/76151412/903870
+  # https://github.com/atc0005/shared-project-resources/issues/135
+  assert_pr_branch_is_ahead_of_primary_branch:
+    name: Assert PR branch is ahead of primary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code (full history)
+        uses: actions/checkout@v3.5.3
+        with:
+          # Full history is needed to allow listing tags via build tooling
+          # (e.g., go-winres, git-describe-semver)
+          fetch-depth: 0
+
+      - name: Check if branch is ahead of master
+        run: |
+          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
+          then echo "This branch is not up to date with primary branch";
+          exit 1; fi
+
   lint_code:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Lint codebase
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -68,10 +90,12 @@ jobs:
           staticcheck $(go list -mod=vendor ./... | grep -v /vendor/)
 
   optional_linting:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Optional Linting
     uses: atc0005/shared-project-resources/.github/workflows/lint-using-optional-linters.yml@master
 
   test_code:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Run tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -110,6 +134,7 @@ jobs:
         run: go test -mod=vendor -v ./...
 
   build_code:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Build codebase
     runs-on: ubuntu-latest
     # Default: 360 minutes

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -16,7 +16,29 @@ on:
         type: boolean
 
 jobs:
+  # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
+  # https://stackoverflow.com/a/76151412/903870
+  # https://github.com/atc0005/shared-project-resources/issues/135
+  assert_pr_branch_is_ahead_of_primary_branch:
+    name: Assert PR branch is ahead of primary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code (full history)
+        uses: actions/checkout@v3.5.3
+        with:
+          # Full history is needed to allow listing tags via build tooling
+          # (e.g., go-winres, git-describe-semver)
+          fetch-depth: 0
+
+      - name: Check if branch is ahead of master
+        run: |
+          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
+          then echo "This branch is not up to date with primary branch";
+          exit 1; fi
+
   lint_code_with_makefile:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Lint codebase using Makefile
     runs-on: ubuntu-latest
     # Default: 360 minutes
@@ -65,6 +87,7 @@ jobs:
         run: make linting
 
   build_code_with_makefile_quick_recipe:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Build codebase using Makefile quick recipe
 
     # NOTE: This recipe should now exist for the majority of projects using
@@ -116,6 +139,7 @@ jobs:
   # The `make all` recipe can be expensive, so we disable it by default
   # and enable it only by explicit request (e.g., monthly scheduled job).
   build_code_with_makefile_all_recipe:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Build codebase using Makefile all recipe
     if: ${{ inputs.build-all }}
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-project-files.yml
+++ b/.github/workflows/lint-project-files.yml
@@ -11,7 +11,29 @@ on:
   workflow_call:
 
 jobs:
+  # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
+  # https://stackoverflow.com/a/76151412/903870
+  # https://github.com/atc0005/shared-project-resources/issues/135
+  assert_pr_branch_is_ahead_of_primary_branch:
+    name: Assert PR branch is ahead of primary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code (full history)
+        uses: actions/checkout@v3.5.3
+        with:
+          # Full history is needed to allow listing tags via build tooling
+          # (e.g., go-winres, git-describe-semver)
+          fetch-depth: 0
+
+      - name: Check if branch is ahead of master
+        run: |
+          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
+          then echo "This branch is not up to date with primary branch";
+          exit 1; fi
+
   lint_markdown:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Lint Markdown files
     runs-on: "ubuntu-latest"
     # Default: 360 minutes
@@ -56,6 +78,7 @@ jobs:
           markdownlint '**/*.md' --ignore node_modules --ignore vendor
 
   lint_dockerfiles:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Lint Dockerfiles
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -9,7 +9,29 @@ on:
   workflow_call:
 
 jobs:
+  # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
+  # https://stackoverflow.com/a/76151412/903870
+  # https://github.com/atc0005/shared-project-resources/issues/135
+  assert_pr_branch_is_ahead_of_primary_branch:
+    name: Assert PR branch is ahead of primary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code (full history)
+        uses: actions/checkout@v3.5.3
+        with:
+          # Full history is needed to allow listing tags via build tooling
+          # (e.g., go-winres, git-describe-semver)
+          fetch-depth: 0
+
+      - name: Check if branch is ahead of master
+        run: |
+          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
+          then echo "This branch is not up to date with primary branch";
+          exit 1; fi
+
   lint_via_optional_linters:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Lint codebase using optional linters
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -28,11 +28,34 @@ on:
         default: true
 
 jobs:
+  # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
+  # https://stackoverflow.com/a/76151412/903870
+  # https://github.com/atc0005/shared-project-resources/issues/135
+  assert_pr_branch_is_ahead_of_primary_branch:
+    name: Assert PR branch is ahead of primary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code (full history)
+        uses: actions/checkout@v3.5.3
+        with:
+          # Full history is needed to allow listing tags via build tooling
+          # (e.g., go-winres, git-describe-semver)
+          fetch-depth: 0
+
+      - name: Check if branch is ahead of master
+        run: |
+          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
+          then echo "This branch is not up to date with primary branch";
+          exit 1; fi
+
   lint_and_build_using_ci_matrix:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: CI matrix
     uses: atc0005/shared-project-resources/.github/workflows/lint-and-build-using-ci-matrix.yml@master
 
   lint_and_build_using_makefile:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Makefile
     with:
       # Pass on any values specified by the importing workflow.
@@ -44,6 +67,7 @@ jobs:
     uses: atc0005/shared-project-resources/.github/workflows/lint-and-build-using-make.yml@master
 
   build_packages_using_container:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Build packages using container
     with:
       # TODO: Override this from the calling/importing workflow if the project
@@ -53,6 +77,7 @@ jobs:
     uses: atc0005/shared-project-resources/.github/workflows/container-builds-packages.yml@master
 
   build_release_assets_using_container:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Build release assets using container
     with:
       # TODO: Override this from the calling/importing workflow if the project

--- a/.github/workflows/scheduled-weekly.yml
+++ b/.github/workflows/scheduled-weekly.yml
@@ -15,15 +15,39 @@ on:
   workflow_call:
 
 jobs:
+  # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
+  # https://stackoverflow.com/a/76151412/903870
+  # https://github.com/atc0005/shared-project-resources/issues/135
+  assert_pr_branch_is_ahead_of_primary_branch:
+    name: Assert PR branch is ahead of primary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code (full history)
+        uses: actions/checkout@v3.5.3
+        with:
+          # Full history is needed to allow listing tags via build tooling
+          # (e.g., go-winres, git-describe-semver)
+          fetch-depth: 0
+
+      - name: Check if branch is ahead of master
+        run: |
+          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
+          then echo "This branch is not up to date with primary branch";
+          exit 1; fi
+
   lint:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Lint
     uses: atc0005/shared-project-resources/.github/workflows/lint-project-files.yml@master
 
   vulnerability:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Vulnerability
     uses: atc0005/shared-project-resources/.github/workflows/vulnerability-analysis.yml@master
 
   go_mod_validation:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Go Module Validation
     uses: atc0005/shared-project-resources/.github/workflows/go-mod-validation.yml@master
 

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -9,7 +9,29 @@ on:
   workflow_call:
 
 jobs:
+  # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
+  # https://stackoverflow.com/a/76151412/903870
+  # https://github.com/atc0005/shared-project-resources/issues/135
+  assert_pr_branch_is_ahead_of_primary_branch:
+    name: Assert PR branch is ahead of primary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code (full history)
+        uses: actions/checkout@v3.5.3
+        with:
+          # Full history is needed to allow listing tags via build tooling
+          # (e.g., go-winres, git-describe-semver)
+          fetch-depth: 0
+
+      - name: Check if branch is ahead of master
+        run: |
+          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
+          then echo "This branch is not up to date with primary branch";
+          exit 1; fi
+
   govulncheck:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
     # https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck
     # https://github.com/golang/vuln
     # https://github.com/atc0005/go-ci/issues/734


### PR DESCRIPTION
Update all workflows:

- add new `assert_pr_branch_is_ahead_of_primary_branch` job
- add new `needs` dependency requirement to all other jobs in the workflow to force the "is current" assertion to complete first before other (potentially more expensive) jobs are allowed to execute

refs GH-135