### PR TITLE
Execute assert current job steps if PR event

### DIFF
--- a/.github/workflows/container-builds-packages.yml
+++ b/.github/workflows/container-builds-packages.yml
@@ -19,11 +19,11 @@ jobs:
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
     name: Assert PR branch is ahead of primary
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check out code (full history)
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.5.3
         with:
           # Full history is needed to allow listing tags via build tooling
@@ -31,6 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check if branch is ahead of master
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
           then echo "This branch is not up to date with primary branch";

--- a/.github/workflows/container-builds-release.yml
+++ b/.github/workflows/container-builds-release.yml
@@ -19,11 +19,11 @@ jobs:
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
     name: Assert PR branch is ahead of primary
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check out code (full history)
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.5.3
         with:
           # Full history is needed to allow listing tags via build tooling
@@ -31,6 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check if branch is ahead of master
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
           then echo "This branch is not up to date with primary branch";

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -14,11 +14,11 @@ jobs:
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
     name: Assert PR branch is ahead of primary
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check out code (full history)
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.5.3
         with:
           # Full history is needed to allow listing tags via build tooling
@@ -26,6 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check if branch is ahead of master
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
           then echo "This branch is not up to date with primary branch";

--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -14,11 +14,11 @@ jobs:
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
     name: Assert PR branch is ahead of primary
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check out code (full history)
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.5.3
         with:
           # Full history is needed to allow listing tags via build tooling
@@ -26,6 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check if branch is ahead of master
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
           then echo "This branch is not up to date with primary branch";

--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -14,11 +14,11 @@ jobs:
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
     name: Assert PR branch is ahead of primary
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check out code (full history)
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.5.3
         with:
           # Full history is needed to allow listing tags via build tooling
@@ -26,6 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check if branch is ahead of master
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
           then echo "This branch is not up to date with primary branch";

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -21,11 +21,11 @@ jobs:
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
     name: Assert PR branch is ahead of primary
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check out code (full history)
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.5.3
         with:
           # Full history is needed to allow listing tags via build tooling
@@ -33,6 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check if branch is ahead of master
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
           then echo "This branch is not up to date with primary branch";

--- a/.github/workflows/lint-project-files.yml
+++ b/.github/workflows/lint-project-files.yml
@@ -20,11 +20,11 @@ jobs:
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
     name: Assert PR branch is ahead of primary
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check out code (full history)
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.5.3
         with:
           # Full history is needed to allow listing tags via build tooling
@@ -32,6 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check if branch is ahead of master
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
           then echo "This branch is not up to date with primary branch";

--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -14,11 +14,11 @@ jobs:
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
     name: Assert PR branch is ahead of primary
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check out code (full history)
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.5.3
         with:
           # Full history is needed to allow listing tags via build tooling
@@ -26,6 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check if branch is ahead of master
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
           then echo "This branch is not up to date with primary branch";

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -33,11 +33,11 @@ jobs:
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
     name: Assert PR branch is ahead of primary
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check out code (full history)
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.5.3
         with:
           # Full history is needed to allow listing tags via build tooling
@@ -45,6 +45,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check if branch is ahead of master
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
           then echo "This branch is not up to date with primary branch";

--- a/.github/workflows/scheduled-weekly.yml
+++ b/.github/workflows/scheduled-weekly.yml
@@ -20,11 +20,11 @@ jobs:
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
     name: Assert PR branch is ahead of primary
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check out code (full history)
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.5.3
         with:
           # Full history is needed to allow listing tags via build tooling
@@ -32,6 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check if branch is ahead of master
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
           then echo "This branch is not up to date with primary branch";

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -14,11 +14,11 @@ jobs:
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
     name: Assert PR branch is ahead of primary
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check out code (full history)
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.5.3
         with:
           # Full history is needed to allow listing tags via build tooling
@@ -26,6 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check if branch is ahead of master
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
           then echo "This branch is not up to date with primary branch";


### PR DESCRIPTION
Skipping the entire job results in all dependent jobs being skipped, so instead try skipping individual job steps so that the whole job technically executes without issue and (hopefully) would not block dependent jobs from executing.

refs GH-135