### PR TITLE
Associate dev builds with development branch

### DIFF
--- a/.github/workflows/container-builds-packages.yml
+++ b/.github/workflows/container-builds-packages.yml
@@ -12,13 +12,25 @@ on:
         required: false
         type: boolean
         default: true
+      default-repo:
+        required: false
+        type: string
+        default: origin
+      primary-branch:
+        required: false
+        type: string
+        default: master
+      development-branch:
+        required: false
+        type: string
+        default: development
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
   # https://stackoverflow.com/a/76151412/903870
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
-    name: Assert PR branch is ahead of primary
+    name: Assert PR branch is ahead
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -30,11 +42,26 @@ jobs:
           # (e.g., go-winres, git-describe-semver)
           fetch-depth: 0
 
-      - name: Check if branch is ahead of master
+      - name: Assert source branches are set
+        run: |
+          abort="false"
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}" == "/" ]] ; then \
+            echo "default repo and primary branch values not set!"; abort="true"; fi
+
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}" == "/" ]] ; then \
+            echo "default repo and development branch values not set!"; abort="true"; fi
+
+          if [[ "$abort" == "true" ]]; then exit 1; fi
+
+          echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
+          echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
-          then echo "This branch is not up to date with primary branch";
+          if ! (git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }} ${{ github.event.pull_request.head.sha }} || \
+            git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }} ${{ github.event.pull_request.head.sha }});
+          then echo "This branch is not up to date with ${{ inputs.primary-branch }} or ${{ inputs.development-branch }} branches!";
           exit 1; fi
 
   build_packages_via_makefile:

--- a/.github/workflows/container-builds-release.yml
+++ b/.github/workflows/container-builds-release.yml
@@ -12,13 +12,25 @@ on:
         required: false
         type: boolean
         default: true
+      default-repo:
+        required: false
+        type: string
+        default: origin
+      primary-branch:
+        required: false
+        type: string
+        default: master
+      development-branch:
+        required: false
+        type: string
+        default: development
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
   # https://stackoverflow.com/a/76151412/903870
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
-    name: Assert PR branch is ahead of primary
+    name: Assert PR branch is ahead
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -30,11 +42,26 @@ jobs:
           # (e.g., go-winres, git-describe-semver)
           fetch-depth: 0
 
-      - name: Check if branch is ahead of master
+      - name: Assert source branches are set
+        run: |
+          abort="false"
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}" == "/" ]] ; then \
+            echo "default repo and primary branch values not set!"; abort="true"; fi
+
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}" == "/" ]] ; then \
+            echo "default repo and development branch values not set!"; abort="true"; fi
+
+          if [[ "$abort" == "true" ]]; then exit 1; fi
+
+          echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
+          echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
-          then echo "This branch is not up to date with primary branch";
+          if ! (git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }} ${{ github.event.pull_request.head.sha }} || \
+            git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }} ${{ github.event.pull_request.head.sha }});
+          then echo "This branch is not up to date with ${{ inputs.primary-branch }} or ${{ inputs.development-branch }} branches!";
           exit 1; fi
 
   podman_release_build_via_makefile:

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -7,13 +7,26 @@
 
 on:
   workflow_call:
+    inputs:
+      default-repo:
+        required: false
+        type: string
+        default: origin
+      primary-branch:
+        required: false
+        type: string
+        default: master
+      development-branch:
+        required: false
+        type: string
+        default: development
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
   # https://stackoverflow.com/a/76151412/903870
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
-    name: Assert PR branch is ahead of primary
+    name: Assert PR branch is ahead
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -25,11 +38,26 @@ jobs:
           # (e.g., go-winres, git-describe-semver)
           fetch-depth: 0
 
-      - name: Check if branch is ahead of master
+      - name: Assert source branches are set
+        run: |
+          abort="false"
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}" == "/" ]] ; then \
+            echo "default repo and primary branch values not set!"; abort="true"; fi
+
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}" == "/" ]] ; then \
+            echo "default repo and development branch values not set!"; abort="true"; fi
+
+          if [[ "$abort" == "true" ]]; then exit 1; fi
+
+          echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
+          echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
-          then echo "This branch is not up to date with primary branch";
+          if ! (git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }} ${{ github.event.pull_request.head.sha }} || \
+            git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }} ${{ github.event.pull_request.head.sha }});
+          then echo "This branch is not up to date with ${{ inputs.primary-branch }} or ${{ inputs.development-branch }} branches!";
           exit 1; fi
 
   dependency_updates:

--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -7,13 +7,26 @@
 
 on:
   workflow_call:
+    inputs:
+      default-repo:
+        required: false
+        type: string
+        default: origin
+      primary-branch:
+        required: false
+        type: string
+        default: master
+      development-branch:
+        required: false
+        type: string
+        default: development
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
   # https://stackoverflow.com/a/76151412/903870
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
-    name: Assert PR branch is ahead of primary
+    name: Assert PR branch is ahead
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -25,11 +38,26 @@ jobs:
           # (e.g., go-winres, git-describe-semver)
           fetch-depth: 0
 
-      - name: Check if branch is ahead of master
+      - name: Assert source branches are set
+        run: |
+          abort="false"
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}" == "/" ]] ; then \
+            echo "default repo and primary branch values not set!"; abort="true"; fi
+
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}" == "/" ]] ; then \
+            echo "default repo and development branch values not set!"; abort="true"; fi
+
+          if [[ "$abort" == "true" ]]; then exit 1; fi
+
+          echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
+          echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
-          then echo "This branch is not up to date with primary branch";
+          if ! (git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }} ${{ github.event.pull_request.head.sha }} || \
+            git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }} ${{ github.event.pull_request.head.sha }});
+          then echo "This branch is not up to date with ${{ inputs.primary-branch }} or ${{ inputs.development-branch }} branches!";
           exit 1; fi
 
   go_mod_changes:

--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -7,13 +7,26 @@
 
 on:
   workflow_call:
+    inputs:
+      default-repo:
+        required: false
+        type: string
+        default: origin
+      primary-branch:
+        required: false
+        type: string
+        default: master
+      development-branch:
+        required: false
+        type: string
+        default: development
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
   # https://stackoverflow.com/a/76151412/903870
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
-    name: Assert PR branch is ahead of primary
+    name: Assert PR branch is ahead
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -25,11 +38,26 @@ jobs:
           # (e.g., go-winres, git-describe-semver)
           fetch-depth: 0
 
-      - name: Check if branch is ahead of master
+      - name: Assert source branches are set
+        run: |
+          abort="false"
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}" == "/" ]] ; then \
+            echo "default repo and primary branch values not set!"; abort="true"; fi
+
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}" == "/" ]] ; then \
+            echo "default repo and development branch values not set!"; abort="true"; fi
+
+          if [[ "$abort" == "true" ]]; then exit 1; fi
+
+          echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
+          echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
-          then echo "This branch is not up to date with primary branch";
+          if ! (git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }} ${{ github.event.pull_request.head.sha }} || \
+            git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }} ${{ github.event.pull_request.head.sha }});
+          then echo "This branch is not up to date with ${{ inputs.primary-branch }} or ${{ inputs.development-branch }} branches!";
           exit 1; fi
 
   lint_code:

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -14,13 +14,25 @@ on:
       build-all:
         required: false
         type: boolean
+      default-repo:
+        required: false
+        type: string
+        default: origin
+      primary-branch:
+        required: false
+        type: string
+        default: master
+      development-branch:
+        required: false
+        type: string
+        default: development
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
   # https://stackoverflow.com/a/76151412/903870
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
-    name: Assert PR branch is ahead of primary
+    name: Assert PR branch is ahead
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -32,11 +44,26 @@ jobs:
           # (e.g., go-winres, git-describe-semver)
           fetch-depth: 0
 
-      - name: Check if branch is ahead of master
+      - name: Assert source branches are set
+        run: |
+          abort="false"
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}" == "/" ]] ; then \
+            echo "default repo and primary branch values not set!"; abort="true"; fi
+
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}" == "/" ]] ; then \
+            echo "default repo and development branch values not set!"; abort="true"; fi
+
+          if [[ "$abort" == "true" ]]; then exit 1; fi
+
+          echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
+          echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
-          then echo "This branch is not up to date with primary branch";
+          if ! (git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }} ${{ github.event.pull_request.head.sha }} || \
+            git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }} ${{ github.event.pull_request.head.sha }});
+          then echo "This branch is not up to date with ${{ inputs.primary-branch }} or ${{ inputs.development-branch }} branches!";
           exit 1; fi
 
   lint_code_with_makefile:

--- a/.github/workflows/lint-project-files.yml
+++ b/.github/workflows/lint-project-files.yml
@@ -6,20 +6,44 @@
 # full license information.
 
 on:
-  pull_request:
-    types: [opened, synchronize]
   workflow_call:
+    inputs:
+      default-repo:
+        required: false
+        type: string
+        default: origin
+      primary-branch:
+        required: false
+        type: string
+        default: master
+      development-branch:
+        required: false
+        type: string
+        default: development
 
   # Allow triggering workflow manually
   # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
   workflow_dispatch:
+    inputs:
+      default-repo:
+        required: false
+        type: string
+        default: origin
+      primary-branch:
+        required: false
+        type: string
+        default: master
+      development-branch:
+        required: false
+        type: string
+        default: development
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
   # https://stackoverflow.com/a/76151412/903870
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
-    name: Assert PR branch is ahead of primary
+    name: Assert PR branch is ahead
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -31,11 +55,26 @@ jobs:
           # (e.g., go-winres, git-describe-semver)
           fetch-depth: 0
 
-      - name: Check if branch is ahead of master
+      - name: Assert source branches are set
+        run: |
+          abort="false"
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}" == "/" ]] ; then \
+            echo "default repo and primary branch values not set!"; abort="true"; fi
+
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}" == "/" ]] ; then \
+            echo "default repo and development branch values not set!"; abort="true"; fi
+
+          if [[ "$abort" == "true" ]]; then exit 1; fi
+
+          echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
+          echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
-          then echo "This branch is not up to date with primary branch";
+          if ! (git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }} ${{ github.event.pull_request.head.sha }} || \
+            git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }} ${{ github.event.pull_request.head.sha }});
+          then echo "This branch is not up to date with ${{ inputs.primary-branch }} or ${{ inputs.development-branch }} branches!";
           exit 1; fi
 
   lint_markdown:

--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -7,13 +7,26 @@
 
 on:
   workflow_call:
+    inputs:
+      default-repo:
+        required: false
+        type: string
+        default: origin
+      primary-branch:
+        required: false
+        type: string
+        default: master
+      development-branch:
+        required: false
+        type: string
+        default: development
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
   # https://stackoverflow.com/a/76151412/903870
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
-    name: Assert PR branch is ahead of primary
+    name: Assert PR branch is ahead
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -25,11 +38,26 @@ jobs:
           # (e.g., go-winres, git-describe-semver)
           fetch-depth: 0
 
-      - name: Check if branch is ahead of master
+      - name: Assert source branches are set
+        run: |
+          abort="false"
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}" == "/" ]] ; then \
+            echo "default repo and primary branch values not set!"; abort="true"; fi
+
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}" == "/" ]] ; then \
+            echo "default repo and development branch values not set!"; abort="true"; fi
+
+          if [[ "$abort" == "true" ]]; then exit 1; fi
+
+          echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
+          echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
-          then echo "This branch is not up to date with primary branch";
+          if ! (git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }} ${{ github.event.pull_request.head.sha }} || \
+            git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }} ${{ github.event.pull_request.head.sha }});
+          then echo "This branch is not up to date with ${{ inputs.primary-branch }} or ${{ inputs.development-branch }} branches!";
           exit 1; fi
 
   lint_via_optional_linters:

--- a/.github/workflows/local-jobs.yml
+++ b/.github/workflows/local-jobs.yml
@@ -1,0 +1,42 @@
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/shared-project-resources
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# Jobs that are local to this repo (not offered to dependent/calling
+# projects).
+
+name: Local Jobs
+
+on:
+  pull_request:
+    # `synchronized` seems to equate to pushing new commits to a linked branch
+    # (whether force-pushed or not)
+    types: [opened, synchronize]
+
+  # Allow triggering workflow manually
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      default-repo:
+        required: false
+        type: string
+        default: origin
+      primary-branch:
+        required: false
+        type: string
+        default: master
+      development-branch:
+        required: false
+        type: string
+        default: development
+
+jobs:
+  lint:
+    # Only run this job on non-push events (e.g., pull requests)
+    if: github.event_name != 'push'
+    name: Lint
+    uses: atc0005/shared-project-resources/.github/workflows/lint-project-files.yml@master
+

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -124,6 +124,7 @@ jobs:
           gh release create ${{ github.ref_name }} \
             --verify-tag \
             --prerelease \
+            --target "development" \
             --discussion-category 'Dev/Release Candidate' \
             --generate-notes \
             $(if [ -d "release_assets" ]; then find release_assets/ -type f; fi)

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -12,6 +12,10 @@ on:
         required: false
         type: boolean
         default: true
+      default-repo:
+        required: false
+        type: string
+        default: origin
       primary-branch:
         required: false
         type: string

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -12,6 +12,14 @@ on:
         required: false
         type: boolean
         default: true
+      primary-branch:
+        required: false
+        type: string
+        default: master
+      development-branch:
+        required: false
+        type: string
+        default: development
 
 jobs:
   test_code:
@@ -113,18 +121,37 @@ jobs:
         if: ${{ inputs.generate-assets }}
         run: make podman-release-build
 
-      - name: Generate pre-release
+      # Releases for "dev" tags are associated with the dedicated development
+      # branch.
+      - name: Generate dev pre-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-        if: contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc')
+        if: contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta')
         run: |
-          echo Generating pre-release
+          echo Generating dev pre-release
 
           gh release create ${{ github.ref_name }} \
             --verify-tag \
             --prerelease \
-            --target "development" \
+            --target "${{ inputs.development-branch }}" \
+            --discussion-category 'Dev/Release Candidate' \
+            --generate-notes \
+            $(if [ -d "release_assets" ]; then find release_assets/ -type f; fi)
+
+      # Releases for "rc" tags are associated with the primary branch where
+      # stable releases are sourced.
+      - name: Generate rc pre-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: contains(github.ref_name, 'rc')
+        run: |
+          echo Generating rc pre-release
+
+          gh release create ${{ github.ref_name }} \
+            --verify-tag \
+            --prerelease \
+            --target "${{ inputs.primary-branch }}" \
             --discussion-category 'Dev/Release Candidate' \
             --generate-notes \
             $(if [ -d "release_assets" ]; then find release_assets/ -type f; fi)
@@ -141,6 +168,7 @@ jobs:
           gh release create ${{ github.ref_name }} \
             --verify-tag \
             --latest \
+            --target "${{ inputs.primary-branch }}" \
             --discussion-category 'Stable Release' \
             --generate-notes \
             $(if [ -d "release_assets" ]; then find release_assets/ -type f; fi)

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -26,13 +26,25 @@ on:
         required: false
         type: boolean
         default: true
+      default-repo:
+        required: false
+        type: string
+        default: origin
+      primary-branch:
+        required: false
+        type: string
+        default: master
+      development-branch:
+        required: false
+        type: string
+        default: development
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
   # https://stackoverflow.com/a/76151412/903870
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
-    name: Assert PR branch is ahead of primary
+    name: Assert PR branch is ahead
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -44,11 +56,26 @@ jobs:
           # (e.g., go-winres, git-describe-semver)
           fetch-depth: 0
 
-      - name: Check if branch is ahead of master
+      - name: Assert source branches are set
+        run: |
+          abort="false"
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}" == "/" ]] ; then \
+            echo "default repo and primary branch values not set!"; abort="true"; fi
+
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}" == "/" ]] ; then \
+            echo "default repo and development branch values not set!"; abort="true"; fi
+
+          if [[ "$abort" == "true" ]]; then exit 1; fi
+
+          echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
+          echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
-          then echo "This branch is not up to date with primary branch";
+          if ! (git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }} ${{ github.event.pull_request.head.sha }} || \
+            git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }} ${{ github.event.pull_request.head.sha }});
+          then echo "This branch is not up to date with ${{ inputs.primary-branch }} or ${{ inputs.development-branch }} branches!";
           exit 1; fi
 
   lint_and_build_using_ci_matrix:

--- a/.github/workflows/scheduled-weekly.yml
+++ b/.github/workflows/scheduled-weekly.yml
@@ -13,13 +13,26 @@
 
 on:
   workflow_call:
+    inputs:
+      default-repo:
+        required: false
+        type: string
+        default: origin
+      primary-branch:
+        required: false
+        type: string
+        default: master
+      development-branch:
+        required: false
+        type: string
+        default: development
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
   # https://stackoverflow.com/a/76151412/903870
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
-    name: Assert PR branch is ahead of primary
+    name: Assert PR branch is ahead
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -31,11 +44,26 @@ jobs:
           # (e.g., go-winres, git-describe-semver)
           fetch-depth: 0
 
-      - name: Check if branch is ahead of master
+      - name: Assert source branches are set
+        run: |
+          abort="false"
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}" == "/" ]] ; then \
+            echo "default repo and primary branch values not set!"; abort="true"; fi
+
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}" == "/" ]] ; then \
+            echo "default repo and development branch values not set!"; abort="true"; fi
+
+          if [[ "$abort" == "true" ]]; then exit 1; fi
+
+          echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
+          echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
-          then echo "This branch is not up to date with primary branch";
+          if ! (git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }} ${{ github.event.pull_request.head.sha }} || \
+            git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }} ${{ github.event.pull_request.head.sha }});
+          then echo "This branch is not up to date with ${{ inputs.primary-branch }} or ${{ inputs.development-branch }} branches!";
           exit 1; fi
 
   lint:

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -7,13 +7,26 @@
 
 on:
   workflow_call:
+    inputs:
+      default-repo:
+        required: false
+        type: string
+        default: origin
+      primary-branch:
+        required: false
+        type: string
+        default: master
+      development-branch:
+        required: false
+        type: string
+        default: development
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
   # https://stackoverflow.com/a/76151412/903870
   # https://github.com/atc0005/shared-project-resources/issues/135
   assert_pr_branch_is_ahead_of_primary_branch:
-    name: Assert PR branch is ahead of primary
+    name: Assert PR branch is ahead
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -25,11 +38,26 @@ jobs:
           # (e.g., go-winres, git-describe-semver)
           fetch-depth: 0
 
-      - name: Check if branch is ahead of master
+      - name: Assert source branches are set
+        run: |
+          abort="false"
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}" == "/" ]] ; then \
+            echo "default repo and primary branch values not set!"; abort="true"; fi
+
+          if [[ "${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}" == "/" ]] ; then \
+            echo "default repo and development branch values not set!"; abort="true"; fi
+
+          if [[ "$abort" == "true" ]]; then exit 1; fi
+
+          echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
+          echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          if ! git merge-base --is-ancestor origin/master ${{ github.event.pull_request.head.sha }};
-          then echo "This branch is not up to date with primary branch";
+          if ! (git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }} ${{ github.event.pull_request.head.sha }} || \
+            git merge-base --is-ancestor ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }} ${{ github.event.pull_request.head.sha }});
+          then echo "This branch is not up to date with ${{ inputs.primary-branch }} or ${{ inputs.development-branch }} branches!";
           exit 1; fi
 
   govulncheck:


### PR DESCRIPTION
These changes are applied in order to directly associate "dev" (alpha, beta) builds with the development branch. Release Candidate (rc) and general releases are associated with the primary (master) branch.

- Associate dev builds with development branch
  - preparing to create a development branch for all dependent projects for pre-release builds
- Associate rc and stable tags with primary branch
  - split release logic into dev, rc and stable releases
  - add optional inputs to allow calling workflows to specify primary and development branch names
- Assert branch is ahead of acceptable source branch
  - update job and step names to better communicate intent
  - add inputs to allow calling workflows to set primary  and development branch names with usable defaults specific to planned changes for dependent projects
  - allow PR branch to be ahead of primary OR development branches (using input values vs hard-coded values)
    - NOTE: This includes the lint-project-files workflow which currently allows triggering the workflow manually