### PR TITLE
Update fetch depth and tag settings

### DIFF
--- a/.github/workflows/container-builds-packages.yml
+++ b/.github/workflows/container-builds-packages.yml
@@ -38,9 +38,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/container-builds-release.yml
+++ b/.github/workflows/container-builds-release.yml
@@ -38,9 +38,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       - name: Assert source branches are set
         run: |
@@ -76,9 +78,11 @@ jobs:
       - name: Check out code (full history)
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       # Mark the current working directory as a safe directory in git to
       # resolve "dubious ownership" complaints.

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -34,9 +34,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -34,9 +34,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -34,9 +34,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -44,9 +44,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       - name: Assert source branches are set
         run: |
@@ -143,9 +145,11 @@ jobs:
       - name: Check out code (full history)
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       # Mark the current working directory as a safe directory in git to
       # resolve "dubious ownership" complaints.
@@ -194,9 +198,11 @@ jobs:
       - name: Check out code (full history)
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       # Mark the current working directory as a safe directory in git to
       # resolve "dubious ownership" complaints.

--- a/.github/workflows/lint-project-files.yml
+++ b/.github/workflows/lint-project-files.yml
@@ -51,9 +51,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -34,9 +34,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -61,9 +61,11 @@ jobs:
       - name: Check out code (full history)
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       # Mark the current working directory as a safe directory in git to
       # resolve "dubious ownership" complaints.
@@ -106,9 +108,11 @@ jobs:
       - name: Check out code (full history)
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       # Mark the current working directory as a safe directory in git to
       # resolve "dubious ownership" complaints.

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -52,9 +52,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/scheduled-weekly.yml
+++ b/.github/workflows/scheduled-weekly.yml
@@ -40,9 +40,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -34,9 +34,11 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3.6.0
         with:
-          # Full history is needed to allow listing tags via build tooling
-          # (e.g., go-winres, git-describe-semver)
-          fetch-depth: 0
+          # Retrieve sufficient amount of history (along with tags) to allow
+          # build tooling (e.g., go-winres, git-describe-semver) to processing
+          # tags as part of asset generation tasks.
+          fetch-depth: 50
+          fetch-tags: true
 
       - name: Assert source branches are set
         run: |


### PR DESCRIPTION
## Changes

Retrieve sufficient amount of history (along with tags) to allow build tooling (e.g., go-winres, git-describe-semver) to processing tags as part of asset generation tasks.

We switch from a full history retrieval ("fetch") to just the last 50 commits along with explicitly requesting tags (associated with those 50 commits).

## References

- fixes GH-148