### PR TITLE
Set fetch-depth input var, fetch additional refs

### DIFF
--- a/.github/workflows/container-builds-packages.yml
+++ b/.github/workflows/container-builds-packages.yml
@@ -24,6 +24,10 @@ on:
         required: false
         type: string
         default: development
+      fetch-depth:
+        required: false
+        type: number
+        default: 50
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
@@ -41,8 +45,13 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
+
+      - name: Fetch additional references
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth 50
+          git fetch origin ${{ inputs.development-branch }} --depth 50
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/container-builds-release.yml
+++ b/.github/workflows/container-builds-release.yml
@@ -24,6 +24,10 @@ on:
         required: false
         type: string
         default: development
+      fetch-depth:
+        required: false
+        type: number
+        default: 50
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
@@ -41,8 +45,13 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
+
+      - name: Fetch additional references
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth 50
+          git fetch origin ${{ inputs.development-branch }} --depth 50
 
       - name: Assert source branches are set
         run: |
@@ -81,7 +90,7 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
 
       # Mark the current working directory as a safe directory in git to

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
         default: development
+      fetch-depth:
+        required: false
+        type: number
+        default: 50
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
@@ -37,8 +41,13 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
+
+      - name: Fetch additional references
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth 50
+          git fetch origin ${{ inputs.development-branch }} --depth 50
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
         default: development
+      fetch-depth:
+        required: false
+        type: number
+        default: 50
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
@@ -37,8 +41,13 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
+
+      - name: Fetch additional references
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth 50
+          git fetch origin ${{ inputs.development-branch }} --depth 50
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
         default: development
+      fetch-depth:
+        required: false
+        type: number
+        default: 50
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
@@ -37,8 +41,13 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
+
+      - name: Fetch additional references
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth 50
+          git fetch origin ${{ inputs.development-branch }} --depth 50
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -30,6 +30,10 @@ on:
         required: false
         type: string
         default: development
+      fetch-depth:
+        required: false
+        type: number
+        default: 50
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
@@ -47,8 +51,13 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
+
+      - name: Fetch additional references
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth 50
+          git fetch origin ${{ inputs.development-branch }} --depth 50
 
       - name: Assert source branches are set
         run: |
@@ -148,7 +157,7 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
 
       # Mark the current working directory as a safe directory in git to
@@ -201,7 +210,7 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
 
       # Mark the current working directory as a safe directory in git to

--- a/.github/workflows/lint-project-files.yml
+++ b/.github/workflows/lint-project-files.yml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
         default: development
+      fetch-depth:
+        required: false
+        type: number
+        default: 50
 
   # Allow triggering workflow manually
   # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
@@ -37,6 +41,10 @@ on:
         required: false
         type: string
         default: development
+      fetch-depth:
+        required: false
+        type: number
+        default: 50
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
@@ -54,8 +62,13 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
+
+      - name: Fetch additional references
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth 50
+          git fetch origin ${{ inputs.development-branch }} --depth 50
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
         default: development
+      fetch-depth:
+        required: false
+        type: number
+        default: 50
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
@@ -37,8 +41,13 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
+
+      - name: Fetch additional references
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth 50
+          git fetch origin ${{ inputs.development-branch }} --depth 50
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/local-jobs.yml
+++ b/.github/workflows/local-jobs.yml
@@ -32,6 +32,10 @@ on:
         required: false
         type: string
         default: development
+      fetch-depth:
+        required: false
+        type: number
+        default: 50
 
 jobs:
   lint:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -24,6 +24,10 @@ on:
         required: false
         type: string
         default: development
+      fetch-depth:
+        required: false
+        type: number
+        default: 50
 
 jobs:
   test_code:
@@ -64,8 +68,13 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
+
+      - name: Fetch additional references
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth 50
+          git fetch origin ${{ inputs.development-branch }} --depth 50
 
       # Mark the current working directory as a safe directory in git to
       # resolve "dubious ownership" complaints.
@@ -111,7 +120,7 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
 
       # Mark the current working directory as a safe directory in git to

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -38,6 +38,10 @@ on:
         required: false
         type: string
         default: development
+      fetch-depth:
+        required: false
+        type: number
+        default: 50
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
@@ -55,8 +59,13 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
+
+      - name: Fetch additional references
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth 50
+          git fetch origin ${{ inputs.development-branch }} --depth 50
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/scheduled-weekly.yml
+++ b/.github/workflows/scheduled-weekly.yml
@@ -26,6 +26,10 @@ on:
         required: false
         type: string
         default: development
+      fetch-depth:
+        required: false
+        type: number
+        default: 50
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
@@ -43,8 +47,13 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
+
+      - name: Fetch additional references
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth 50
+          git fetch origin ${{ inputs.development-branch }} --depth 50
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
         default: development
+      fetch-depth:
+        required: false
+        type: number
+        default: 50
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
@@ -37,8 +41,13 @@ jobs:
           # Retrieve sufficient amount of history (along with tags) to allow
           # build tooling (e.g., go-winres, git-describe-semver) to processing
           # tags as part of asset generation tasks.
-          fetch-depth: 50
+          fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
+
+      - name: Fetch additional references
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth 50
+          git fetch origin ${{ inputs.development-branch }} --depth 50
 
       - name: Assert source branches are set
         run: |


### PR DESCRIPTION
- set/use inputs.fetch-depth instead of hardcoded value within each actions/checkout usage
- fetch primary/dev branches at same depth as PR branch in an attempt to resolve assertion comparision failures

refs GH-148