### PR TITLE
Make development branch fetch optional

### DIFF
--- a/.github/workflows/container-builds-packages.yml
+++ b/.github/workflows/container-builds-packages.yml
@@ -51,7 +51,9 @@ jobs:
       - name: Fetch additional references
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth 50
-          git fetch origin ${{ inputs.development-branch }} --depth 50
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth 50 || true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/container-builds-release.yml
+++ b/.github/workflows/container-builds-release.yml
@@ -51,7 +51,9 @@ jobs:
       - name: Fetch additional references
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth 50
-          git fetch origin ${{ inputs.development-branch }} --depth 50
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth 50 || true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -47,7 +47,9 @@ jobs:
       - name: Fetch additional references
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth 50
-          git fetch origin ${{ inputs.development-branch }} --depth 50
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth 50 || true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -47,7 +47,9 @@ jobs:
       - name: Fetch additional references
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth 50
-          git fetch origin ${{ inputs.development-branch }} --depth 50
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth 50 || true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -47,7 +47,9 @@ jobs:
       - name: Fetch additional references
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth 50
-          git fetch origin ${{ inputs.development-branch }} --depth 50
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth 50 || true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -57,7 +57,9 @@ jobs:
       - name: Fetch additional references
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth 50
-          git fetch origin ${{ inputs.development-branch }} --depth 50
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth 50 || true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/lint-project-files.yml
+++ b/.github/workflows/lint-project-files.yml
@@ -68,7 +68,9 @@ jobs:
       - name: Fetch additional references
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth 50
-          git fetch origin ${{ inputs.development-branch }} --depth 50
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth 50 || true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -47,7 +47,9 @@ jobs:
       - name: Fetch additional references
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth 50
-          git fetch origin ${{ inputs.development-branch }} --depth 50
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth 50 || true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -74,7 +74,9 @@ jobs:
       - name: Fetch additional references
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth 50
-          git fetch origin ${{ inputs.development-branch }} --depth 50
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth 50 || true
 
       # Mark the current working directory as a safe directory in git to
       # resolve "dubious ownership" complaints.

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -65,7 +65,9 @@ jobs:
       - name: Fetch additional references
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth 50
-          git fetch origin ${{ inputs.development-branch }} --depth 50
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth 50 || true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/scheduled-weekly.yml
+++ b/.github/workflows/scheduled-weekly.yml
@@ -53,7 +53,9 @@ jobs:
       - name: Fetch additional references
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth 50
-          git fetch origin ${{ inputs.development-branch }} --depth 50
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth 50 || true
 
       - name: Assert source branches are set
         run: |

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -47,7 +47,9 @@ jobs:
       - name: Fetch additional references
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth 50
-          git fetch origin ${{ inputs.development-branch }} --depth 50
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth 50 || true
 
       - name: Assert source branches are set
         run: |


### PR DESCRIPTION
Attempt to fetch development branch, fallback to ignoring the attempt. We do not filter out the failure message (should it occur) for future troubleshooting purposes.

refs GH-148