### PR TITLE
Attempt to workaround GitHub release build errors

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -62,21 +62,24 @@ jobs:
           echo "Ref full: ${{ github.ref }}"
           echo "Commit SHA: ${{ github.sha }}"
 
-      - name: Check out code (subset)
+      - name: Check out code
         uses: actions/checkout@v3.6.0
-        with:
-          # Retrieve sufficient amount of history (along with tags) to allow
-          # build tooling (e.g., go-winres, git-describe-semver) to processing
-          # tags as part of asset generation tasks.
-          fetch-depth: ${{ inputs.fetch-depth }}
-          fetch-tags: true
 
-      - name: Fetch additional references
-        run: |
-          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
-
-          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
-          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
+#       - name: Check out code (subset)
+#         uses: actions/checkout@v3.6.0
+#         with:
+#           # Retrieve sufficient amount of history (along with tags) to allow
+#           # build tooling (e.g., go-winres, git-describe-semver) to processing
+#           # tags as part of asset generation tasks.
+#           fetch-depth: ${{ inputs.fetch-depth }}
+#           fetch-tags: true
+#
+#       - name: Fetch additional references
+#         run: |
+#           git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
+#
+#           # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+#           git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
 
       # Mark the current working directory as a safe directory in git to
       # resolve "dubious ownership" complaints.


### PR DESCRIPTION
Revert to using default options for actions/checkout action for release build workflow.

refs GH-156
refs GH-148