### PR TITLE
Add missing "is PR event" check to monthly jobs

### DIFF
--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -63,6 +63,7 @@ jobs:
           fetch-tags: true
 
       - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
 


### PR DESCRIPTION
Add this check to the 'Fetch additional references' step to prevent it from executing for the 'Assert PR branch is ahead' job in the monthly workflow.

refs GH-160