### PR TITLE
Add missing "is PR event" check to refs fetch step

### DIFF
--- a/.github/workflows/container-builds-packages.yml
+++ b/.github/workflows/container-builds-packages.yml
@@ -49,6 +49,7 @@ jobs:
           fetch-tags: true
 
       - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
 

--- a/.github/workflows/container-builds-release.yml
+++ b/.github/workflows/container-builds-release.yml
@@ -49,6 +49,7 @@ jobs:
           fetch-tags: true
 
       - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
 

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -45,6 +45,7 @@ jobs:
           fetch-tags: true
 
       - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
 

--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -45,6 +45,7 @@ jobs:
           fetch-tags: true
 
       - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
 

--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -45,6 +45,7 @@ jobs:
           fetch-tags: true
 
       - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
 

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -55,6 +55,7 @@ jobs:
           fetch-tags: true
 
       - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
 

--- a/.github/workflows/lint-project-files.yml
+++ b/.github/workflows/lint-project-files.yml
@@ -66,6 +66,7 @@ jobs:
           fetch-tags: true
 
       - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
 

--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -45,6 +45,7 @@ jobs:
           fetch-tags: true
 
       - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
 

--- a/.github/workflows/scheduled-weekly.yml
+++ b/.github/workflows/scheduled-weekly.yml
@@ -51,6 +51,7 @@ jobs:
           fetch-tags: true
 
       - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
 

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -45,6 +45,7 @@ jobs:
           fetch-tags: true
 
       - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
 


### PR DESCRIPTION
Add this check to the 'Fetch additional references' step to prevent it from executing for the 'Assert PR branch is ahead' job for non-PR events.

This commit builds on top of the change from
bcde85660eb24c17b7b2568423aab790f548e91d

refs GH-160