### PR TITLE
Rework fetch settings, assertion order, doc notes

### DIFF
--- a/.github/workflows/container-builds-packages.yml
+++ b/.github/workflows/container-builds-packages.yml
@@ -38,24 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out code (subset)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v3.6.0
-        with:
-          # Retrieve sufficient amount of history (along with tags) to allow
-          # build tooling (e.g., go-winres, git-describe-semver) to processing
-          # tags as part of asset generation tasks.
-          fetch-depth: ${{ inputs.fetch-depth }}
-          fetch-tags: true
-
-      - name: Fetch additional references
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
-
-          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
-          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
-
       - name: Assert source branches are set
         run: |
           abort="false"
@@ -69,6 +51,24 @@ jobs:
 
           echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
           echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Check out code (subset)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3.6.0
+        with:
+          # Retrieve sufficient amount of history to allow build tooling
+          # (e.g., go-winres, git-describe-semver) to process tags as part of
+          # asset generation tasks.
+          fetch-depth: ${{ inputs.fetch-depth }}
+          fetch-tags: true
+
+      - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
 
       - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}
@@ -98,8 +98,22 @@ jobs:
       - name: Print go version
         run: go version
 
-      - name: Check out code into the Go module directory
+      - name: Check out code (subset)
         uses: actions/checkout@v3.6.0
+        with:
+          # Retrieve sufficient amount of history to allow build tooling
+          # (e.g., go-winres, git-describe-semver) to process tags as part of
+          # asset generation tasks.
+          fetch-depth: ${{ inputs.fetch-depth }}
+          fetch-tags: true
+
+      - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
 
       # Mark the current working directory as a safe directory in git to
       # resolve "dubious ownership" complaints.

--- a/.github/workflows/container-builds-release.yml
+++ b/.github/workflows/container-builds-release.yml
@@ -38,24 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out code (subset)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v3.6.0
-        with:
-          # Retrieve sufficient amount of history (along with tags) to allow
-          # build tooling (e.g., go-winres, git-describe-semver) to processing
-          # tags as part of asset generation tasks.
-          fetch-depth: ${{ inputs.fetch-depth }}
-          fetch-tags: true
-
-      - name: Fetch additional references
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
-
-          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
-          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
-
       - name: Assert source branches are set
         run: |
           abort="false"
@@ -69,6 +51,20 @@ jobs:
 
           echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
           echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Check out code (subset)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3.6.0
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
 
       - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}
@@ -90,11 +86,19 @@ jobs:
       - name: Check out code (subset)
         uses: actions/checkout@v3.6.0
         with:
-          # Retrieve sufficient amount of history (along with tags) to allow
-          # build tooling (e.g., go-winres, git-describe-semver) to processing
-          # tags as part of asset generation tasks.
+          # Retrieve sufficient amount of history to allow build tooling
+          # (e.g., go-winres, git-describe-semver) to process tags as part of
+          # asset generation tasks.
           fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
+
+      - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
 
       # Mark the current working directory as a safe directory in git to
       # resolve "dubious ownership" complaints.

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -34,24 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out code (subset)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v3.6.0
-        with:
-          # Retrieve sufficient amount of history (along with tags) to allow
-          # build tooling (e.g., go-winres, git-describe-semver) to processing
-          # tags as part of asset generation tasks.
-          fetch-depth: ${{ inputs.fetch-depth }}
-          fetch-tags: true
-
-      - name: Fetch additional references
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
-
-          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
-          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
-
       - name: Assert source branches are set
         run: |
           abort="false"
@@ -65,6 +47,20 @@ jobs:
 
           echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
           echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Check out code (subset)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3.6.0
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
 
       - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/go-mod-validation.yml
+++ b/.github/workflows/go-mod-validation.yml
@@ -34,24 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out code (subset)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v3.6.0
-        with:
-          # Retrieve sufficient amount of history (along with tags) to allow
-          # build tooling (e.g., go-winres, git-describe-semver) to processing
-          # tags as part of asset generation tasks.
-          fetch-depth: ${{ inputs.fetch-depth }}
-          fetch-tags: true
-
-      - name: Fetch additional references
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
-
-          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
-          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
-
       - name: Assert source branches are set
         run: |
           abort="false"
@@ -65,6 +47,20 @@ jobs:
 
           echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
           echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Check out code (subset)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3.6.0
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
 
       - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -34,24 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out code (subset)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v3.6.0
-        with:
-          # Retrieve sufficient amount of history (along with tags) to allow
-          # build tooling (e.g., go-winres, git-describe-semver) to processing
-          # tags as part of asset generation tasks.
-          fetch-depth: ${{ inputs.fetch-depth }}
-          fetch-tags: true
-
-      - name: Fetch additional references
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
-
-          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
-          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
-
       - name: Assert source branches are set
         run: |
           abort="false"
@@ -65,6 +47,20 @@ jobs:
 
           echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
           echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Check out code (subset)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3.6.0
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
 
       - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -44,24 +44,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out code (subset)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v3.6.0
-        with:
-          # Retrieve sufficient amount of history (along with tags) to allow
-          # build tooling (e.g., go-winres, git-describe-semver) to processing
-          # tags as part of asset generation tasks.
-          fetch-depth: ${{ inputs.fetch-depth }}
-          fetch-tags: true
-
-      - name: Fetch additional references
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
-
-          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
-          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
-
       - name: Assert source branches are set
         run: |
           abort="false"
@@ -75,6 +57,20 @@ jobs:
 
           echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
           echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Check out code (subset)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3.6.0
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
 
       - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}
@@ -156,12 +152,6 @@ jobs:
 
       - name: Check out code (subset)
         uses: actions/checkout@v3.6.0
-        with:
-          # Retrieve sufficient amount of history (along with tags) to allow
-          # build tooling (e.g., go-winres, git-describe-semver) to processing
-          # tags as part of asset generation tasks.
-          fetch-depth: ${{ inputs.fetch-depth }}
-          fetch-tags: true
 
       # Mark the current working directory as a safe directory in git to
       # resolve "dubious ownership" complaints.
@@ -210,11 +200,18 @@ jobs:
       - name: Check out code (subset)
         uses: actions/checkout@v3.6.0
         with:
-          # Retrieve sufficient amount of history (along with tags) to allow
-          # build tooling (e.g., go-winres, git-describe-semver) to processing
-          # tags as part of asset generation tasks.
+          # Retrieve sufficient amount of history to allow build tooling
+          # (e.g., go-winres, git-describe-semver) to process tags as part of
+          # asset generation tasks.
           fetch-depth: ${{ inputs.fetch-depth }}
           fetch-tags: true
+
+      - name: Fetch additional references
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
 
       # Mark the current working directory as a safe directory in git to
       # resolve "dubious ownership" complaints.

--- a/.github/workflows/lint-project-files.yml
+++ b/.github/workflows/lint-project-files.yml
@@ -55,24 +55,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out code (subset)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v3.6.0
-        with:
-          # Retrieve sufficient amount of history (along with tags) to allow
-          # build tooling (e.g., go-winres, git-describe-semver) to processing
-          # tags as part of asset generation tasks.
-          fetch-depth: ${{ inputs.fetch-depth }}
-          fetch-tags: true
-
-      - name: Fetch additional references
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
-
-          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
-          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
-
       - name: Assert source branches are set
         run: |
           abort="false"
@@ -86,6 +68,20 @@ jobs:
 
           echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
           echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Check out code (subset)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3.6.0
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
 
       - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -23,7 +23,7 @@ on:
       fetch-depth:
         required: false
         type: number
-        default: 50
+        default: 1
 
 jobs:
   # https://stackoverflow.com/questions/76151411/use-github-actions-to-check-if-branch-is-up-to-date-with-main
@@ -34,24 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out code (subset)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v3.6.0
-        with:
-          # Retrieve sufficient amount of history (along with tags) to allow
-          # build tooling (e.g., go-winres, git-describe-semver) to processing
-          # tags as part of asset generation tasks.
-          fetch-depth: ${{ inputs.fetch-depth }}
-          fetch-tags: true
-
-      - name: Fetch additional references
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
-
-          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
-          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
-
       - name: Assert source branches are set
         run: |
           abort="false"
@@ -65,6 +47,20 @@ jobs:
 
           echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
           echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Check out code (subset)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3.6.0
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
 
       - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -52,24 +52,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out code (subset)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v3.6.0
-        with:
-          # Retrieve sufficient amount of history (along with tags) to allow
-          # build tooling (e.g., go-winres, git-describe-semver) to processing
-          # tags as part of asset generation tasks.
-          fetch-depth: ${{ inputs.fetch-depth }}
-          fetch-tags: true
-
-      - name: Fetch additional references
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
-
-          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
-          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
-
       - name: Assert source branches are set
         run: |
           abort="false"
@@ -83,6 +65,20 @@ jobs:
 
           echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
           echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Check out code (subset)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3.6.0
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
 
       - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/scheduled-weekly.yml
+++ b/.github/workflows/scheduled-weekly.yml
@@ -40,23 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out code (subset)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v3.6.0
-        with:
-          # Retrieve sufficient amount of history (along with tags) to allow
-          # build tooling (e.g., go-winres, git-describe-semver) to processing
-          # tags as part of asset generation tasks.
-          fetch-depth: ${{ inputs.fetch-depth }}
-          fetch-tags: true
-
-      - name: Fetch additional references
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
-
-          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
-          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
       - name: Assert source branches are set
         run: |
           abort="false"
@@ -70,6 +53,20 @@ jobs:
 
           echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
           echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Check out code (subset)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3.6.0
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
 
       - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -34,24 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out code (subset)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v3.6.0
-        with:
-          # Retrieve sufficient amount of history (along with tags) to allow
-          # build tooling (e.g., go-winres, git-describe-semver) to processing
-          # tags as part of asset generation tasks.
-          fetch-depth: ${{ inputs.fetch-depth }}
-          fetch-tags: true
-
-      - name: Fetch additional references
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
-
-          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
-          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
-
       - name: Assert source branches are set
         run: |
           abort="false"
@@ -65,6 +47,20 @@ jobs:
 
           echo "Primary branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.primary-branch) }}"
           echo "Development branch: ${{ format('{0}/{1}', inputs.default-repo, inputs.development-branch) }}"
+
+      - name: Check out code (subset)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3.6.0
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Fetch additional references
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ inputs.primary-branch }} --depth ${{ inputs.fetch-depth }}
+
+          # Allow fetch attempts for ${{ inputs.development-branch }} to fail
+          git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
 
       - name: Assert PR branch is ahead of acceptable source branches
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Of note:

- move 'Assert source branches are set' check first within 'Assert PR branch is ahead' job as it needs to run and is the cheapest way to fail fast if required values are not set
- simplify code check step where extended options are not needed (see also GH-163 for future work)
- add missing 'Fetch additional references' step for jobs where version calculation is needed (most build & package generation tasks)