### PR TITLE
Expose optional linter module version info

### DIFF
--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -116,17 +116,20 @@ jobs:
 
       - name: Run orijtech/structslop
         run: |
-          echo "structslop version $(go version -m $(which structslop) | awk '$1 == "mod" { print $3 }')"
+          #echo "structslop version $(go version -m $(which structslop) | awk '$1 == "mod" { print $3 }')"
+          go version -m $(which structslop)
           structslop ./...
 
       - name: Run orijtech/tickeryzer
         run: |
-          echo "tickeryzer version $(go version -m $(which tickeryzer) | awk '$1 == "mod" { print $3 }')"
+          #echo "tickeryzer version $(go version -m $(which tickeryzer) | awk '$1 == "mod" { print $3 }')"
+          go version -m $(which tickeryzer)
           tickeryzer ./...
 
       - name: Run orijtech/httperroryzer
         run: |
-          echo "httperroryzer version $(go version -m $(which httperroryzer) | awk '$1 == "mod" { print $3 }')"
+          #echo "httperroryzer version $(go version -m $(which httperroryzer) | awk '$1 == "mod" { print $3 }')"
+          go version -m $(which httperroryzer)
           httperroryzer ./...
 
       - name: Run fatih/errwrap


### PR DESCRIPTION
Instead of emitting only the specific release/tag version info, emit the full module version details provided by running "go version -m BINARY".

This is intended to compliment temporary changes to build and package forked copies of the linters provided by the orijtech GitHub Org. The goal is to emit detailed version info until PRs are accepted into the applicable upstream repos to update required dependencies to allow those linters to run using newer Go versions.

At that point the plan is to switch back to emitting only basic module version info since we would be one again using the latest upstream version of the linters.