### PR TITLE
Expose optional linter module version info redux

### DIFF
--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -134,7 +134,8 @@ jobs:
 
       - name: Run fatih/errwrap
         run: |
-          echo "errwrap version $(go version -m $(which errwrap) | awk '$1 == "mod" { print $3 }')"
+          #echo "errwrap version $(go version -m $(which errwrap) | awk '$1 == "mod" { print $3 }')"
+          go version -m $(which errwrap)
           errwrap ./...
 
       # DISABLED until further review:


### PR DESCRIPTION
Instead of emitting only the specific release/tag version info, emit the full module version details provided by running "go version -m BINARY".

This is intended to compliment temporary changes to build and package forked copies of the linters called by this workflow.

The goal is to emit detailed version info until PRs are accepted into the applicable upstream repos to update required dependencies to allow those linters to run using newer Go versions.

At that point the plan is to switch back to emitting only basic module version info since we would be one again using the latest upstream version of the linters.

See also:

- atc0005/shared-project-resources#174