### PR TITLE
Temporarily disable optional linters in stable img

### DIFF
--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -94,7 +94,8 @@ jobs:
       # Don't stop all workflow jobs if the unstable image linting tasks fail.
       fail-fast: false
       matrix:
-        container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
+        # container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
+        container-image: ["go-ci-oldstable","go-ci-unstable"]
         experimental: [true]
     container:
       image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}"


### PR DESCRIPTION
Skip running optional linters set in the stable image as a workaround for the upstream version of those linters being incompatible with Go 1.22.

Once the stable image(s) have been rebuilt with hotfixes to workaround that incompatibility we can re-enable them.

refs atc0005/go-ci#1400