### PR TITLE
Revert "Temporarily disable optional linters in stable img"

### DIFF
--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -94,8 +94,7 @@ jobs:
       # Don't stop all workflow jobs if the unstable image linting tasks fail.
       fail-fast: false
       matrix:
-        # container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
-        container-image: ["go-ci-oldstable","go-ci-unstable"]
+        container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
         experimental: [true]
     container:
       image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}"


### PR DESCRIPTION
This reverts commit 6281c7628d2b29ef82fb602a8bfa67404af6d165.

refs atc0005/go-ci#1400
refs atc0005/shared-project-resources#177