### PR TITLE
Update govulncheck version listing logic

### DIFF
--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -99,5 +99,5 @@ jobs:
 
       - name: Analyze source code
         run: |
-          echo "govulncheck version $(go version -m $(which govulncheck) | awk '$1 == "mod" { print $3 }')"
+          govulncheck --version
           govulncheck -json ./...


### PR DESCRIPTION
Use `--version` flag supported by newer govulncheck releases instead of slicing/dicing Go module version details.

fixes GH-170