### PR TITLE
Add job to evaluate Go 1.22 loop behavior changes

### DIFF
--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -184,6 +184,43 @@ jobs:
       - name: Run all tests
         run: go test -mod=vendor -v ./...
 
+  # https://github.com/atc0005/shared-project-resources/issues/145
+  evaluate_loopvar_scoping_changes:
+    needs: assert_pr_branch_is_ahead_of_primary_branch
+    name: Evaluate loopvar scoping changes
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+    # Don't flag the whole workflow as failed if this job fails. Once this
+    # workflow job proves itself we can mark it as required.
+    continue-on-error: true
+    container:
+      image: "ghcr.io/atc0005/go-ci:go-ci-mirror-build-go1.21"
+
+    steps:
+      - name: Print go version
+        run: go version
+
+      - name: Check out code
+        uses: actions/checkout@v4.1.1
+
+      # Mark the current working directory as a safe directory in git to
+      # resolve "dubious ownership" complaints.
+      #
+      # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      # https://confluence.atlassian.com/bbkb/git-command-returns-fatal-error-about-the-repository-being-owned-by-someone-else-1167744132.html
+      # https://github.com/actions/runner-images/issues/6775
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the current working directory as a safe directory in git
+        # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory "${PWD}"
+
+      - name: Assert loopvar flag does not change loop compilation behavior
+        run: >-
+          ! go build -gcflags=all=-d=loopvar=2 $(go list -mod=vendor ./...) 2>&1
+          | grep -Ev 'vendor/|/usr'
+          | grep --quiet 'now per-iteration'
+
   build_code:
     needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Build codebase


### PR DESCRIPTION
Use Go 1.21 series "mirror" image to perform builds using the `loopvar` compiler flag. This new workflow job will be ued to identify loops that compile differently using the new loop semantics introduced as a preview in Go 1.21 and enabled by default with the release of Go 1.22.

This new workflow job is set to `continue-on-error` in order to verify that it works as intended. Once it has been proven to work as intended `continue-on-error` will be set to `false` and any identified loop behavior changes will be considered a real CI failure requiring resolution.

refs GH-145