### PR TITLE
Do not ignore loopvar behavior matches

### DIFF
--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -219,7 +219,7 @@ jobs:
         run: >-
           ! go build -gcflags=all=-d=loopvar=2 $(go list -mod=vendor ./...) 2>&1
           | grep -Ev 'vendor/|/usr'
-          | grep --quiet 'now per-iteration'
+          | grep 'now per-iteration'
 
   build_code:
     needs: assert_pr_branch_is_ahead_of_primary_branch


### PR DESCRIPTION
Remove the `--quiet` flag which previously (and erroneously) discarded match output.