### PR TITLE
Enable failing CI on loopvar behavior matches

### DIFF
--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -191,9 +191,10 @@ jobs:
     runs-on: ubuntu-latest
     # Default: 360 minutes
     timeout-minutes: 10
-    # Don't flag the whole workflow as failed if this job fails. Once this
-    # workflow job proves itself we can mark it as required.
-    continue-on-error: true
+    # Brief testing indicates the syntax of this job is correct and that the
+    # matches are not false-positives; we'll treat linting failures as real
+    # errors.
+    continue-on-error: false
     container:
       image: "ghcr.io/atc0005/go-ci:go-ci-mirror-build-go1.21"
 


### PR DESCRIPTION
Brief testing has shown (or at least suggested) that the new CI job works as intended so turning off setting to ignore errors from this job so that CI failure will be flagged.

refs:

- GH-145