### PR TITLE
Update more CI workflows to accept custom OS deps

### DIFF
--- a/.github/workflows/container-builds-packages.yml
+++ b/.github/workflows/container-builds-packages.yml
@@ -8,6 +8,9 @@
 on:
   workflow_call:
     inputs:
+      os-dependencies:
+        required: false
+        type: string
       build-packages:
         required: false
         type: boolean
@@ -128,6 +131,10 @@ jobs:
       - name: Mark the current working directory as a safe directory in git
         # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
         run: git config --global --add safe.directory "${PWD}"
+
+      - name: Install Ubuntu packages (custom set)
+        if: ${{ inputs.os-dependencies != '' }}
+        run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.os-dependencies }}
 
       - name: Fetch additional references
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/lint-and-build-using-ci-matrix.yml
+++ b/.github/workflows/lint-and-build-using-ci-matrix.yml
@@ -8,6 +8,9 @@
 on:
   workflow_call:
     inputs:
+      os-dependencies:
+        required: false
+        type: string
       default-repo:
         required: false
         type: string
@@ -117,6 +120,10 @@ jobs:
         # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
         run: git config --global --add safe.directory "${PWD}"
 
+      - name: Install Ubuntu packages (custom set)
+        if: ${{ inputs.os-dependencies != '' }}
+        run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.os-dependencies }}
+
       - name: Remove repo-provided golangci-lint config file
         run: |
           # Remove the copy of the config file bundled with the repo/code so
@@ -143,6 +150,9 @@ jobs:
   optional_linting:
     needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Optional Linting
+    with:
+      # Pass on any values specified by the importing workflow.
+      os-dependencies: ${{ inputs.os-dependencies }}
     uses: atc0005/shared-project-resources/.github/workflows/lint-using-optional-linters.yml@master
 
   test_code:
@@ -181,6 +191,10 @@ jobs:
         # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
         run: git config --global --add safe.directory "${PWD}"
 
+      - name: Install Ubuntu packages (custom set)
+        if: ${{ inputs.os-dependencies != '' }}
+        run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.os-dependencies }}
+
       - name: Run all tests
         run: go test -mod=vendor -v ./...
 
@@ -215,6 +229,10 @@ jobs:
       - name: Mark the current working directory as a safe directory in git
         # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
         run: git config --global --add safe.directory "${PWD}"
+
+      - name: Install Ubuntu packages (custom set)
+        if: ${{ inputs.os-dependencies != '' }}
+        run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.os-dependencies }}
 
       - name: Assert loopvar flag does not change loop compilation behavior
         run: >-
@@ -261,6 +279,10 @@ jobs:
       - name: Mark the current working directory as a safe directory in git
         # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
         run: git config --global --add safe.directory "${PWD}"
+
+      - name: Install Ubuntu packages (custom set)
+        if: ${{ inputs.os-dependencies != '' }}
+        run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.os-dependencies }}
 
       - name: Build using vendored dependencies
         # NOTE: This will fail if there is a doc.go file in the project root

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -120,9 +120,14 @@ jobs:
         # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
         run: git config --global --add safe.directory "${PWD}"
 
-      # bsdmainutils provides "column" which is used by the Makefile
-      - name: Install Ubuntu packages
-        run: apt-get update && apt-get install -y --no-install-recommends make gcc bsdmainutils
+      - name: Install Ubuntu packages (standard set)
+        if: ${{ inputs.os-dependencies == '' }}
+        # bsdmainutils provides "column" which is used by the Makefile
+        run: apt-get update && apt-get install -y --no-install-recommends make gcc bsdmainutils xz-utils
+
+      - name: Install Ubuntu packages (custom set)
+        if: ${{ inputs.os-dependencies != '' }}
+        run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.os-dependencies }}
 
       - name: Install Go linting tools
         run: make lintinstall

--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -8,6 +8,9 @@
 on:
   workflow_call:
     inputs:
+      os-dependencies:
+        required: false
+        type: string
       default-repo:
         required: false
         type: string
@@ -113,6 +116,10 @@ jobs:
       - name: Mark the current working directory as a safe directory in git
         # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
         run: git config --global --add safe.directory "${PWD}"
+
+      - name: Install Ubuntu packages (custom set)
+        if: ${{ inputs.os-dependencies != '' }}
+        run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.os-dependencies }}
 
       - name: Run orijtech/structslop
         run: |

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -102,6 +102,9 @@ jobs:
   lint_and_build_using_ci_matrix:
     needs: assert_pr_branch_is_ahead_of_primary_branch
     name: CI matrix
+    with:
+      # Pass on any values specified by the importing workflow.
+      os-dependencies: ${{ inputs.os-dependencies }}
     uses: atc0005/shared-project-resources/.github/workflows/lint-and-build-using-ci-matrix.yml@master
 
   lint_and_build_using_makefile:
@@ -145,6 +148,9 @@ jobs:
     needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Build packages using container
     with:
+      # Pass on any values specified by the importing workflow.
+      os-dependencies: ${{ inputs.os-dependencies }}
+
       # TODO: Override this from the calling/importing workflow if the project
       # does not support generating release assets directly (e.g., library
       # project).
@@ -155,6 +161,9 @@ jobs:
     needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Build release assets using container
     with:
+      # Pass on any values specified by the importing workflow.
+      os-dependencies: ${{ inputs.os-dependencies }}
+
       # TODO: Override this from the calling/importing workflow if the project
       # does not support generating release assets directly (e.g., library
       # project).

--- a/.github/workflows/scheduled-weekly.yml
+++ b/.github/workflows/scheduled-weekly.yml
@@ -14,6 +14,9 @@
 on:
   workflow_call:
     inputs:
+      os-dependencies:
+        required: false
+        type: string
       default-repo:
         required: false
         type: string
@@ -90,11 +93,17 @@ jobs:
   lint:
     needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Lint
+    with:
+      # Pass on any values specified by the importing workflow.
+      os-dependencies: ${{ inputs.os-dependencies }}
     uses: atc0005/shared-project-resources/.github/workflows/lint-project-files.yml@master
 
   vulnerability:
     needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Vulnerability
+    with:
+      # Pass on any values specified by the importing workflow.
+      os-dependencies: ${{ inputs.os-dependencies }}
     uses: atc0005/shared-project-resources/.github/workflows/vulnerability-analysis.yml@master
 
   go_mod_validation:

--- a/.github/workflows/vulnerability-analysis.yml
+++ b/.github/workflows/vulnerability-analysis.yml
@@ -8,6 +8,9 @@
 on:
   workflow_call:
     inputs:
+      os-dependencies:
+        required: false
+        type: string
       default-repo:
         required: false
         type: string
@@ -96,6 +99,10 @@ jobs:
       - name: Mark the current working directory as a safe directory in git
         # run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
         run: git config --global --add safe.directory "${PWD}"
+
+      - name: Install Ubuntu packages (custom set)
+        if: ${{ inputs.os-dependencies != '' }}
+        run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.os-dependencies }}
 
       - name: Analyze source code
         run: |


### PR DESCRIPTION
The goal is to accept custom OS deps to account for projects with special build requirements (e.g., CGO builds with fixed OS dependency requirements).