### PR TITLE
Explicitly generate release notes for pre-releases

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -159,12 +159,28 @@ jobs:
         run: |
           echo Generating dev pre-release
 
+          echo "Calculating previous pre-release tag for use with API request"
+          previous_tag=$(git tag -l | grep -E 'alpha|beta' | sort -V | tail -n 2 | head -n 1)
+          release_notes_markdown_file="${{ runner.temp }}/tmp-release-notes.md"
+
+          echo "Generating release notes from API using explicit previous tag"
+          gh api \
+              -X POST 'repos/{owner}/{repo}/releases/generate-notes' \
+              -f tag_name="${{ github.ref_name }}" \
+              -f previous_tag_name="${previous_tag}" \
+              -f commitish="${{ inputs.development-branch }}"  \
+              --jq '.body' > "${release_notes_markdown_file}"
+
+          echo "Add newline before and after header level 3 (admittedly nitpicky)"
+          sed -i -e 's/###/\n###/g' -e 's/\(###.*\)/\1\n/g' "${release_notes_markdown_file}"
+
+          echo "Generating release using previously generated release notes"
           gh release create ${{ github.ref_name }} \
             --verify-tag \
             --prerelease \
             --target "${{ inputs.development-branch }}" \
             --discussion-category 'Dev/Release Candidate' \
-            --generate-notes \
+            --notes-file "${release_notes_markdown_file}" \
             $(if [ -d "release_assets" ]; then find release_assets/ -type f; fi)
 
       # Releases for "rc" tags are associated with the primary branch where


### PR DESCRIPTION
Calculate previous tag and use that when generating release notes for pre-releases. This works around an apparent (recent) bug in the automatic release notes generation process.

fixes GH-188