### PR TITLE
Troubleshooting release notes generation

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -157,11 +157,15 @@ jobs:
 
         if: contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta')
         run: |
-          echo Generating dev pre-release
+          echo "Generating dev pre-release for ${{ github.ref_name }}"
 
           echo "Calculating previous pre-release tag for use with API request"
           previous_tag=$(git tag -l | grep -E 'alpha|beta' | sort -V | tail -n 2 | head -n 1)
+          echo "previous_tag is ${previous_tag}"
+
+          echo "Setting path for generated release notes"
           release_notes_markdown_file="${{ runner.temp }}/tmp-release-notes.md"
+          echo "release_notes_markdown_file is ${release_notes_markdown_file}"
 
           echo "Generating release notes from API using explicit previous tag"
           gh api \
@@ -170,6 +174,9 @@ jobs:
               -f previous_tag_name="${previous_tag}" \
               -f commitish="${{ inputs.development-branch }}"  \
               --jq '.body' > "${release_notes_markdown_file}"
+
+          echo "First 10 lines of generated release notes before formatting tweaks"
+          head "${release_notes_markdown_file}"
 
           echo "Add newline before and after header level 3 (admittedly nitpicky)"
           sed -i -e 's/###/\n###/g' -e 's/\(###.*\)/\1\n/g' "${release_notes_markdown_file}"


### PR DESCRIPTION
The previous attempt to generate release notes for pre-release tags resulted in an empty release notes body.

Adding additional debug details to try and pinpoint the problem (which I'll fix in a later PR).

refs GH-188