### PR TITLE
Remove invalid `with` value from monthly workflow

### DIFF
--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -161,9 +161,6 @@ jobs:
     needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Build release assets using container
     with:
-      # Pass on any values specified by the importing workflow.
-      os-dependencies: ${{ inputs.os-dependencies }}
-
       # TODO: Override this from the calling/importing workflow if the project
       # does not support generating release assets directly (e.g., library
       # project).


### PR DESCRIPTION
The `os-dependencies` value is not used by the called `container-builds-release.yml` workflow.