### PR TITLE
Add support for enabling i386 architecture

### DIFF
--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -14,6 +14,9 @@ on:
       build-all:
         required: false
         type: boolean
+      enable-i386-architecture:
+        required: false
+        type: boolean
       lint-using-makefile:
         required: false
         type: boolean
@@ -239,6 +242,15 @@ jobs:
 
           # Allow fetch attempts for ${{ inputs.development-branch }} to fail
           git fetch origin ${{ inputs.development-branch }} --depth ${{ inputs.fetch-depth }} || true
+
+      - name: Enable i386 architecture to allow 32-bit package installation (optional)
+        if: ${{ inputs.enable-i386-architecture }}
+        continue-on-error: false
+        # https://unix.stackexchange.com/questions/12956/how-do-i-run-32-bit-programs-on-a-64-bit-debian-ubuntu
+        run: |
+          dpkg --add-architecture i386
+          dpkg --configure -a
+          apt-get update
 
       - name: Install Ubuntu packages (standard set)
         if: ${{ inputs.os-dependencies == '' }}

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -26,6 +26,14 @@ on:
         required: false
         type: boolean
         default: true
+      makefile-build-all:
+        required: false
+        type: boolean
+        default: true
+      makefile-enable-i386-architecture:
+        required: false
+        type: boolean
+        default: false
       default-repo:
         required: false
         type: string
@@ -140,8 +148,16 @@ jobs:
       lint-using-makefile: true
 
       # The `make all` recipe can be expensive, so we disable it by default
-      # and enable it here as part of a scheduled monthly job.
-      build-all: true
+      # and enable it here (by default) as part of a scheduled monthly job.
+      #
+      # We use a workflow input to allow toggling this off as needed by
+      # dependent projects.
+      build-all: ${{ inputs.makefile-build-all }}
+
+      # Some CGO-enabled projects require i386 packages to be installed if
+      # building x86 assets on a x64 OS. This is opt-in as most projects do
+      # not require this build option.
+      enable-i386-architecture: ${{ inputs.makefile-enable-i386-architecture }}
     uses: atc0005/shared-project-resources/.github/workflows/lint-and-build-using-make.yml@master
 
   build_packages_using_container:


### PR DESCRIPTION
## Changes

- update `lint-and-build-using-make.yml` workflow
  - add `enable-i386-architecture` input, default `false`
  - add workflow step to add `i386` architecture
- update `scheduled-monthly.yml`
  - add `makefile-build-all` input, default `true` - this was previously hardcoded to `true`, now customizable from called workflows
  - add `makefile-enable-i386-architecture` input, default `false`
    - this is new, used to accept desired value from dependent projects otherwise defaults to previous behavior

## References

- atc0005/safelinks#325