### PR TITLE
Rework support for enabling i386 architecture

### DIFF
--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -11,6 +11,9 @@ on:
       os-dependencies:
         required: false
         type: string
+      makefile-all-os-dependencies:
+        required: false
+        type: string
       build-all:
         required: false
         type: boolean
@@ -252,14 +255,21 @@ jobs:
           dpkg --configure -a
           apt-get update
 
+      - name: Refresh Ubuntu packages lists
+        run: apt-get update
+
       - name: Install Ubuntu packages (standard set)
         if: ${{ inputs.os-dependencies == '' }}
         # bsdmainutils provides "column" which is used by the Makefile
-        run: apt-get update && apt-get install -y --no-install-recommends make gcc bsdmainutils xz-utils
+        run: apt-get install -y --no-install-recommends make gcc bsdmainutils xz-utils
 
       - name: Install Ubuntu packages (custom set)
         if: ${{ inputs.os-dependencies != '' }}
-        run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.os-dependencies }}
+        run: apt-get install -y --no-install-recommends ${{ inputs.os-dependencies }}
+
+      - name: Install Ubuntu packages (optional makefile all set)
+        if: ${{ inputs.makefile-all-os-dependencies != '' }}
+        run: apt-get install -y --no-install-recommends ${{ inputs.makefile-all-os-dependencies }}
 
       # Try to install build dependencies using the depsinstall Makefile
       # recipe but allow this step to fail without failing the whole job if

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -18,6 +18,9 @@ on:
       os-dependencies:
         required: false
         type: string
+      makefile-all-os-dependencies:
+        required: false
+        type: string
       build-packages:
         required: false
         type: boolean
@@ -119,8 +122,15 @@ jobs:
     needs: assert_pr_branch_is_ahead_of_primary_branch
     name: Makefile
     with:
-      # Pass on any values specified by the importing workflow.
+      # Optional custom set of OS dependencies. If the calling workflow does
+      # not specify a custom set a default set will be used instead.
       os-dependencies: ${{ inputs.os-dependencies }}
+
+      # Optional additional set of OS dependencies intended specifically for
+      # the Makefile `all` recipe.
+      #
+      # refs https://github.com/atc0005/safelinks/issues/325
+      makefile-all-os-dependencies: ${{ inputs.makefile-all-os-dependencies }}
 
       # Makefile-initiated linting tasks use the latest upstream versions of
       # community standard linting tools (e.g., staticcheck, golangci-lint)
@@ -147,8 +157,9 @@ jobs:
       # refs https://github.com/atc0005/shared-project-resources/issues/149
       lint-using-makefile: true
 
-      # The `make all` recipe can be expensive, so we disable it by default
-      # and enable it here (by default) as part of a scheduled monthly job.
+      # The Makefile `all` recipe can be expensive, so it is disabled by
+      # default in the called workflow. We enable it here by default as part
+      # of a scheduled monthly job.
       #
       # We use a workflow input to allow toggling this off as needed by
       # dependent projects.
@@ -157,6 +168,11 @@ jobs:
       # Some CGO-enabled projects require i386 packages to be installed if
       # building x86 assets on a x64 OS. This is opt-in as most projects do
       # not require this build option.
+      #
+      # See also the `makefile-all-os-dependencies` workflow input where i386
+      # architecture packages can be specified (e.g., `libxcursor-dev:i386`).
+      #
+      # refs https://github.com/atc0005/safelinks/issues/325
       enable-i386-architecture: ${{ inputs.makefile-enable-i386-architecture }}
     uses: atc0005/shared-project-resources/.github/workflows/lint-and-build-using-make.yml@master
 


### PR DESCRIPTION
## Changes

- update `lint-and-build-using-make.yml` workflow
  - add `makefile-all-os-dependencies` input
  - move `apt-get update` to separate step to reduce duplication
  - add additional package installation step specific to `make all` invocations
- update `scheduled-monthly.yml`
  - add `makefile-all-os-dependencies` input
  - misc doc comments cleanup
  - pass `makefile-all-os-dependencies` input to called `lint-and-build-using-make.yml` workflow

## References

- atc0005/safelinks#325