### PR TITLE
Remove duplicate pkg lists update

### DIFF
--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -253,7 +253,6 @@ jobs:
         run: |
           dpkg --add-architecture i386
           dpkg --configure -a
-          apt-get update
 
       - name: Refresh Ubuntu packages lists
         run: apt-get update


### PR DESCRIPTION
Remove duplicate `apt-get update` call from the step used to enable i386 architecture since this is now handled by an explicit step right after this one.