### PR TITLE
Disable structslop linter for unstable image

### DIFF
--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -122,6 +122,9 @@ jobs:
         run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.os-dependencies }}
 
       - name: Run orijtech/structslop
+        # Not provided by unstable image
+        # https://github.com/atc0005/go-ci/pull/1586
+        if: ${{ matrix.container-image != 'go-ci-unstable' }}
         run: |
           #echo "structslop version $(go version -m $(which structslop) | awk '$1 == "mod" { print $3 }')"
           go version -m $(which structslop)


### PR DESCRIPTION
refs https://github.com/atc0005/go-ci/pull/1586