### PR TITLE
Troubleshooting disabling of structslop linter

### DIFF
--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -126,6 +126,7 @@ jobs:
         # https://github.com/atc0005/go-ci/pull/1586
         if: ${{ matrix.container-image != 'go-ci-unstable' }}
         run: |
+          echo 'matrix.container-image' value is ${{ matrix.container-image }}
           #echo "structslop version $(go version -m $(which structslop) | awk '$1 == "mod" { print $3 }')"
           go version -m $(which structslop)
           structslop ./...


### PR DESCRIPTION
Echo current value of `${{ matrix.container-image }}` as part of linter execution block; the changes from GH-204 do not seem to be working as intended.