### PR TITLE
Reuse tag instead of calculating for release build

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -95,6 +95,14 @@ jobs:
   release_build:
     name: Release build using Podman and Makefile
 
+    env:
+      # Set environment variable so that our Makefile can take advantage of
+      # that value instead of calculating the tag from scratch. This also
+      # helps with cases where the current commit has multiple tags associated
+      # with it (e.g., a final release tag created from a commit which also
+      # has the last release candidate tag).
+      REPO_VERSION: "${{ github.ref_name }}"
+
     # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
     permissions:
       contents: write


### PR DESCRIPTION
The Makefile used by dependenent projects attempts to reuse the `REPO_VERSION` environment variable if set, otherwise falls back to generating a new value using `git-describe-semver`.

This tool becomes confused if two tags point to the same commit and does not know which tag to list (ideally the latest stable tag if matching the same commit as a RC tag) so we work around that by always having release builds use the tag provided by GitHub Actions (which matches exactly the tag pushed).