### PR TITLE
Revert "Disable structslop linter for unstable image"

### DIFF
--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -122,9 +122,6 @@ jobs:
         run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.os-dependencies }}
 
       - name: Run orijtech/structslop
-        # Not provided by unstable image
-        # https://github.com/atc0005/go-ci/pull/1586
-        if: ${{ matrix.container-image != 'go-ci-unstable' }}
         run: |
           echo 'matrix.container-image' value is ${{ matrix.container-image }}
           #echo "structslop version $(go version -m $(which structslop) | awk '$1 == "mod" { print $3 }')"


### PR DESCRIPTION
This reverts commit 53521c3656fcccfc80bc22b83d8fa8e36aa54686.

- fixes https://github.com/atc0005/shared-project-resources/issues/209 
- refs https://github.com/atc0005/go-ci/issues/1684