### PR TITLE
Remove orijtech/httperroryzer linter

### DIFF
--- a/.github/workflows/lint-using-optional-linters.yml
+++ b/.github/workflows/lint-using-optional-linters.yml
@@ -121,12 +121,6 @@ jobs:
         if: ${{ inputs.os-dependencies != '' }}
         run: apt-get update && apt-get install -y --no-install-recommends ${{ inputs.os-dependencies }}
 
-      - name: Run orijtech/httperroryzer
-        run: |
-          #echo "httperroryzer version $(go version -m $(which httperroryzer) | awk '$1 == "mod" { print $3 }')"
-          go version -m $(which httperroryzer)
-          httperroryzer ./...
-
       # DISABLED until further review:
       #
       #   - linting suggestions do not seem to apply


### PR DESCRIPTION
Linter is no longer supported (per upstream repo activity), so removing from active use.

- refs atc0005/go-ci#1848
- fixes GH-224
