### PR TITLE
Exclude empty files from releases

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -209,7 +209,7 @@ jobs:
               --discussion-category 'Dev/Release Candidate' \
               --title "${{ github.ref_name }}" \
               --notes-file "${release_notes_markdown_file}" \
-              $(if [ -d "release_assets" ]; then find release_assets/ -type f; fi)
+              $(if [ -d "release_assets" ]; then find release_assets/ -type f -size +0; fi)
           else
             echo "Calling workflow disabled discussions; skipping creation of new release discussion ..."
             gh release create ${{ github.ref_name }} \
@@ -218,7 +218,7 @@ jobs:
               --target "${{ inputs.development-branch }}" \
               --title "${{ github.ref_name }}" \
               --notes-file "${release_notes_markdown_file}" \
-              $(if [ -d "release_assets" ]; then find release_assets/ -type f; fi)
+              $(if [ -d "release_assets" ]; then find release_assets/ -type f -size +0; fi)
           fi
 
       # Releases for "rc" tags are associated with the primary branch where
@@ -238,7 +238,7 @@ jobs:
               --discussion-category 'Dev/Release Candidate' \
               --title "${{ github.ref_name }}" \
               --generate-notes \
-              $(if [ -d "release_assets" ]; then find release_assets/ -type f; fi)
+              $(if [ -d "release_assets" ]; then find release_assets/ -type f -size +0; fi)
           else
             echo "Calling workflow disabled discussions; skipping creation of new release discussion ..."
             gh release create ${{ github.ref_name }} \
@@ -247,7 +247,7 @@ jobs:
               --target "${{ inputs.primary-branch }}" \
               --title "${{ github.ref_name }}" \
               --generate-notes \
-              $(if [ -d "release_assets" ]; then find release_assets/ -type f; fi)
+              $(if [ -d "release_assets" ]; then find release_assets/ -type f -size +0; fi)
           fi
 
       - name: Generate stable release
@@ -267,7 +267,7 @@ jobs:
               --discussion-category 'Stable Release' \
               --title "${{ github.ref_name }}" \
               --generate-notes \
-              $(if [ -d "release_assets" ]; then find release_assets/ -type f; fi)
+              $(if [ -d "release_assets" ]; then find release_assets/ -type f -size +0; fi)
           else
             echo "Calling workflow disabled discussions; skipping creation of new release discussion ..."
             gh release create ${{ github.ref_name }} \
@@ -276,5 +276,5 @@ jobs:
               --target "${{ inputs.primary-branch }}" \
               --title "${{ github.ref_name }}" \
               --generate-notes \
-              $(if [ -d "release_assets" ]; then find release_assets/ -type f; fi)
+              $(if [ -d "release_assets" ]; then find release_assets/ -type f -size +0; fi)
           fi


### PR DESCRIPTION
Add `-size +0` flag and setting to limit release asset uploads to files containing content. While providing empty files (when generated that way) was the intended outcome, this approach avoids failing releases with an API `HTTP 400: Bad Content-Length` error response.